### PR TITLE
Credentials Verifier Maven artifact

### DIFF
--- a/extensions/identity-hub-verifier/build.gradle.kts
+++ b/extensions/identity-hub-verifier/build.gradle.kts
@@ -43,3 +43,12 @@ dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter-api:${jupiterVersion}")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:${jupiterVersion}")
 }
+
+publishing {
+    publications {
+        create<MavenPublication>("identity-hub-credentials-verifier") {
+            artifactId = "identity-hub-credentials-verifier"
+            from(components["java"])
+        }
+    }
+}

--- a/extensions/identity-hub-verifier/src/main/java/org/eclipse/dataspaceconnector/identityhub/verifier/CredentialsVerifierExtension.java
+++ b/extensions/identity-hub-verifier/src/main/java/org/eclipse/dataspaceconnector/identityhub/verifier/CredentialsVerifierExtension.java
@@ -37,9 +37,6 @@ import static java.lang.String.format;
 @Requires({ DidPublicKeyResolver.class })
 public class CredentialsVerifierExtension implements ServiceExtension {
 
-    @EdcSetting
-    private static final String HUB_URL_SETTING = "edc.identity.hub.url";
-
     @Inject
     private OkHttpClient httpClient;
 
@@ -71,11 +68,6 @@ public class CredentialsVerifierExtension implements ServiceExtension {
 
     @Provider
     public CredentialsVerifier createCredentialsVerifier(ServiceExtensionContext context) {
-        var hubUrl = context.getSetting(HUB_URL_SETTING, null);
-        if (hubUrl == null) {
-            throw new EdcException(format("Mandatory setting '(%s)' missing", HUB_URL_SETTING));
-        }
-
         var client = new IdentityHubClientImpl(httpClient, typeManager.getMapper(), monitor);
         var verifiableCredentialsJwtService = new VerifiableCredentialsJwtServiceImpl(typeManager.getMapper());
         return new IdentityHubCredentialsVerifier(client, monitor, jwtCredentialsVerifier, verifiableCredentialsJwtService);

--- a/extensions/identity-hub-verifier/src/main/java/org/eclipse/dataspaceconnector/identityhub/verifier/CredentialsVerifierExtension.java
+++ b/extensions/identity-hub-verifier/src/main/java/org/eclipse/dataspaceconnector/identityhub/verifier/CredentialsVerifierExtension.java
@@ -19,8 +19,6 @@ import org.eclipse.dataspaceconnector.iam.did.spi.credentials.CredentialsVerifie
 import org.eclipse.dataspaceconnector.iam.did.spi.resolution.DidPublicKeyResolver;
 import org.eclipse.dataspaceconnector.identityhub.client.IdentityHubClientImpl;
 import org.eclipse.dataspaceconnector.identityhub.credentials.VerifiableCredentialsJwtServiceImpl;
-import org.eclipse.dataspaceconnector.spi.EdcException;
-import org.eclipse.dataspaceconnector.spi.EdcSetting;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.system.Inject;
 import org.eclipse.dataspaceconnector.spi.system.Provider;
@@ -28,8 +26,6 @@ import org.eclipse.dataspaceconnector.spi.system.Requires;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtension;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
 import org.eclipse.dataspaceconnector.spi.types.TypeManager;
-
-import static java.lang.String.format;
 
 /**
  * Extension to provide verification of IdentityHub Verifiable Credentials.

--- a/extensions/identity-hub-verifier/src/test/java/org/eclipse/dataspaceconnector/identityhub/verifier/CredentialsVerifierExtensionTest.java
+++ b/extensions/identity-hub-verifier/src/test/java/org/eclipse/dataspaceconnector/identityhub/verifier/CredentialsVerifierExtensionTest.java
@@ -60,7 +60,7 @@ public class CredentialsVerifierExtensionTest {
         identityHubClient = new IdentityHubClientImpl(TestUtils.testOkHttpClient(), new ObjectMapper(), new ConsoleMonitor());
         publicKeyResolver = mock(DidPublicKeyResolverImpl.class);
         extension.registerServiceMock(DidPublicKeyResolver.class, publicKeyResolver);
-        extension.setConfiguration(Map.of("web.http.port", String.valueOf(PORT), "edc.identity.hub.url", API_URL));
+        extension.setConfiguration(Map.of("web.http.port", String.valueOf(PORT)));
     }
 
     @Test


### PR DESCRIPTION
## What this PR changes/adds

Publish IdentityHub Credentials Verifier to Maven, so that it can be used in MVD EDC.

## Why it does that

## Further notes

Also removed unused setting (which we forgot to remove in a previous PR).

## Linked Issue(s)

https://github.com/agera-edc/IdentityHub/issues/21

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/identityservice/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/identityservice/blob/main/styleguide.md) for details_)
