### PR TITLE
Add issue time JWT claim

### DIFF
--- a/spi/identity-hub-spi/src/main/java/org/eclipse/dataspaceconnector/identityhub/credentials/VerifiableCredentialsJwtServiceImpl.java
+++ b/spi/identity-hub-spi/src/main/java/org/eclipse/dataspaceconnector/identityhub/credentials/VerifiableCredentialsJwtServiceImpl.java
@@ -26,6 +26,7 @@ import org.eclipse.dataspaceconnector.spi.result.Result;
 
 import java.text.ParseException;
 import java.util.AbstractMap;
+import java.util.Date;
 import java.util.Map;
 import java.util.Objects;
 
@@ -42,6 +43,7 @@ public class VerifiableCredentialsJwtServiceImpl implements VerifiableCredential
         var claims = new JWTClaimsSet.Builder()
                 .claim(VERIFIABLE_CREDENTIALS_KEY, credential)
                 .issuer(issuer)
+                .issueTime(new Date())
                 .subject(subject)
                 .build();
 

--- a/spi/identity-hub-spi/src/test/java/org/eclipse/dataspaceconnector/identityhub/credentials/VerifiableCredentialsJwtServiceTest.java
+++ b/spi/identity-hub-spi/src/test/java/org/eclipse/dataspaceconnector/identityhub/credentials/VerifiableCredentialsJwtServiceTest.java
@@ -26,6 +26,9 @@ import org.eclipse.dataspaceconnector.identityhub.credentials.model.VerifiableCr
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.time.Instant;
+
+import static java.time.temporal.ChronoUnit.SECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.InstanceOfAssertFactories.map;
 import static org.eclipse.dataspaceconnector.identityhub.credentials.VerifiableCredentialsJwtService.VERIFIABLE_CREDENTIALS_KEY;
@@ -55,6 +58,7 @@ public class VerifiableCredentialsJwtServiceTest {
         // Arrange
         var issuer = FAKER.lorem().word();
         var subject = FAKER.lorem().word();
+        var startTime = Instant.now().truncatedTo(SECONDS);
 
         // Act
         var signedJwt = service.buildSignedJwt(VERIFIABLE_CREDENTIAL, issuer, subject, privateKey);
@@ -63,7 +67,7 @@ public class VerifiableCredentialsJwtServiceTest {
         boolean result = signedJwt.verify(publicKey.verifier());
         assertThat(result).isTrue();
 
-        assertThat(signedJwt.getPayload().toJSONObject())
+        assertThat(signedJwt.getJWTClaimsSet().toJSONObject())
                 .containsEntry("iss", issuer)
                 .containsEntry("sub", subject)
                 .extractingByKey(VERIFIABLE_CREDENTIALS_KEY)
@@ -72,6 +76,7 @@ public class VerifiableCredentialsJwtServiceTest {
                             .usingRecursiveComparison()
                             .isEqualTo(VERIFIABLE_CREDENTIAL);
                 });
+        assertThat(signedJwt.getJWTClaimsSet().getIssueTime()).isBetween(startTime, Instant.now());
     }
 
     @Test


### PR DESCRIPTION
## What this PR changes/adds

Add issue time claim to VC JWT payload.

## Why it does that

This allows writing system tests in registration service that can wait for VCs to be pushed to Identity Hub. With an issue time, tests can run multiple times and ensure a new VC was generated (vs. a VC from a previous test run).

## Further notes

## Linked Issue(s)

https://github.com/agera-edc/MinimumViableDataspace/issues/13

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/identityservice/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/identityservice/blob/main/styleguide.md) for details_)
