### PR TITLE
chore: use EDC M5 version

### DIFF
--- a/.github/actions/gradle-setup/action.yml
+++ b/.github/actions/gradle-setup/action.yml
@@ -3,41 +3,9 @@ description: "Setup Gradle"
 runs:
   using: "composite"
   steps:
-    # Checkout EDC code into DataSpaceConnector directory.
-    - name: Checkout EDC
-      uses: actions/checkout@v2
-      with:
-        repository: eclipse-dataspaceconnector/DataSpaceConnector
-        path: DataSpaceConnector
-        ref: v0.0.1-milestone-5
-
     # Install Java and cache MVD Gradle build.
     - uses: actions/setup-java@v2
       with:
         java-version: '17'
         distribution: 'temurin'
         cache: 'gradle'
-
-    # Cache EDC packages (installed into ~/.m2) in-between runs.
-    # If the latest EDC commit ID has not changed since the last run, this will restore
-    # its Maven packages from the cache.
-    - name: Cache EDC packages
-      uses: actions/cache@v3
-      id: cache
-      with:
-        path: ~/.m2
-        # .git/FETCH_HEAD contains latest commit ID
-        key: ${{ runner.os }}-m2-${{ hashFiles('DataSpaceConnector/.git/FETCH_HEAD') }}
-
-    # Install EDC packages into ~/.m2.
-    # This action only runs if the packages could not be restored from the cache.
-    - name: Build EDC packages
-      run: |
-        ./gradlew publishToMavenLocal -Pskip.signing
-      if: steps.cache.outputs.cache-hit != 'true' # only on cache miss
-      shell: bash
-      working-directory: DataSpaceConnector
-
-    - name: Delete EDC packages
-      run: rm -r DataSpaceConnector
-      shell: bash

--- a/.github/actions/gradle-setup/action.yml
+++ b/.github/actions/gradle-setup/action.yml
@@ -9,7 +9,7 @@ runs:
       with:
         repository: eclipse-dataspaceconnector/DataSpaceConnector
         path: DataSpaceConnector
-        ref: 56a6ac8749774ed1d8af582134320ba7caf5c1d3
+        ref: v0.0.1-milestone-5
 
     # Install Java and cache MVD Gradle build.
     - uses: actions/setup-java@v2

--- a/extensions/identity-hub-verifier/src/test/java/org/eclipse/dataspaceconnector/identityhub/verifier/CredentialsVerifierExtensionTest.java
+++ b/extensions/identity-hub-verifier/src/test/java/org/eclipse/dataspaceconnector/identityhub/verifier/CredentialsVerifierExtensionTest.java
@@ -16,16 +16,20 @@ package org.eclipse.dataspaceconnector.identityhub.verifier;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.javafaker.Faker;
-import org.eclipse.dataspaceconnector.iam.did.resolution.DidPublicKeyResolverImpl;
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.jwk.ECKey;
 import org.eclipse.dataspaceconnector.iam.did.spi.credentials.CredentialsVerifier;
 import org.eclipse.dataspaceconnector.iam.did.spi.document.DidDocument;
+import org.eclipse.dataspaceconnector.iam.did.spi.document.EllipticCurvePublicKey;
 import org.eclipse.dataspaceconnector.iam.did.spi.document.Service;
-import org.eclipse.dataspaceconnector.iam.did.spi.resolution.DidPublicKeyResolver;
+import org.eclipse.dataspaceconnector.iam.did.spi.resolution.DidResolver;
+import org.eclipse.dataspaceconnector.iam.did.spi.resolution.DidResolverRegistry;
 import org.eclipse.dataspaceconnector.identityhub.client.IdentityHubClient;
 import org.eclipse.dataspaceconnector.identityhub.client.IdentityHubClientImpl;
 import org.eclipse.dataspaceconnector.junit.extensions.EdcExtension;
 import org.eclipse.dataspaceconnector.junit.testfixtures.TestUtils;
 import org.eclipse.dataspaceconnector.spi.monitor.ConsoleMonitor;
+import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.result.Result;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -39,7 +43,6 @@ import static org.eclipse.dataspaceconnector.identityhub.junit.testfixtures.Veri
 import static org.eclipse.dataspaceconnector.identityhub.junit.testfixtures.VerifiableCredentialTestUtil.generateEcKey;
 import static org.eclipse.dataspaceconnector.identityhub.junit.testfixtures.VerifiableCredentialTestUtil.generateVerifiableCredential;
 import static org.eclipse.dataspaceconnector.identityhub.junit.testfixtures.VerifiableCredentialTestUtil.toMap;
-import static org.eclipse.dataspaceconnector.identityhub.junit.testfixtures.VerifiableCredentialTestUtil.toPublicKeyWrapper;
 import static org.eclipse.dataspaceconnector.junit.testfixtures.TestUtils.getFreePort;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
@@ -50,24 +53,28 @@ public class CredentialsVerifierExtensionTest {
     private static final Faker FAKER = new Faker();
     private static final int PORT = getFreePort();
     private static final String API_URL = String.format("http://localhost:%d/api/identity-hub", PORT);
-    private static final String CREDENTIAL_ISSUER = FAKER.internet().url();
+    private static final String CREDENTIAL_ISSUER = "did:web:testdid";
     private static final String SUBJECT = FAKER.internet().url();
     private IdentityHubClient identityHubClient;
-    private DidPublicKeyResolver publicKeyResolver;
 
     @BeforeEach
     void setUp(EdcExtension extension) {
         identityHubClient = new IdentityHubClientImpl(TestUtils.testOkHttpClient(), new ObjectMapper(), new ConsoleMonitor());
-        publicKeyResolver = mock(DidPublicKeyResolverImpl.class);
-        extension.registerServiceMock(DidPublicKeyResolver.class, publicKeyResolver);
+        extension.registerServiceMock(Monitor.class, mock(Monitor.class));
         extension.setConfiguration(Map.of("web.http.port", String.valueOf(PORT)));
     }
 
     @Test
-    public void getVerifiedClaims_getValidClaims(CredentialsVerifier verifier) {
-        // Arrange
+    public void getVerifiedClaims_getValidClaims(CredentialsVerifier verifier, DidResolverRegistry registry) {
+
         var jwk = generateEcKey();
-        when(publicKeyResolver.resolvePublicKey(anyString())).thenReturn(Result.success(toPublicKeyWrapper(jwk)));
+        // Arrange - add did resolver that returns a dummy DID
+        var didResolver = mock(DidResolver.class);
+        var did = createDidDocument(jwk);
+        when(didResolver.resolve(anyString())).thenReturn(Result.success(did));
+        when(didResolver.getMethod()).thenReturn("web");
+        registry.register(didResolver);
+
         var didDocument = DidDocument.Builder.newInstance()
                 .id(SUBJECT)
                 .service(List.of(new Service("IdentityHub", "IdentityHub", API_URL)))
@@ -85,5 +92,11 @@ public class CredentialsVerifierExtensionTest {
         assertThat(credentials.getContent())
                 .usingRecursiveComparison()
                 .isEqualTo(expectedCredentials);
+    }
+
+    private DidDocument createDidDocument(ECKey jwk) {
+        var ecPK = new EllipticCurvePublicKey(jwk.getCurve().getName(), jwk.getKeyType().toString(), jwk.getX().toString(), jwk.getY().toString());
+        return DidDocument.Builder.newInstance()
+                .verificationMethod("test-id", "test-type", ecPK).build();
     }
 }

--- a/extensions/identity-hub-verifier/src/test/java/org/eclipse/dataspaceconnector/identityhub/verifier/CredentialsVerifierExtensionTest.java
+++ b/extensions/identity-hub-verifier/src/test/java/org/eclipse/dataspaceconnector/identityhub/verifier/CredentialsVerifierExtensionTest.java
@@ -16,7 +16,6 @@ package org.eclipse.dataspaceconnector.identityhub.verifier;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.javafaker.Faker;
-import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.jwk.ECKey;
 import org.eclipse.dataspaceconnector.iam.did.spi.credentials.CredentialsVerifier;
 import org.eclipse.dataspaceconnector.iam.did.spi.document.DidDocument;
@@ -95,8 +94,8 @@ public class CredentialsVerifierExtensionTest {
     }
 
     private DidDocument createDidDocument(ECKey jwk) {
-        var ecPK = new EllipticCurvePublicKey(jwk.getCurve().getName(), jwk.getKeyType().toString(), jwk.getX().toString(), jwk.getY().toString());
+        var ecPk = new EllipticCurvePublicKey(jwk.getCurve().getName(), jwk.getKeyType().toString(), jwk.getX().toString(), jwk.getY().toString());
         return DidDocument.Builder.newInstance()
-                .verificationMethod("test-id", "test-type", ecPK).build();
+                .verificationMethod("test-id", "test-type", ecPk).build();
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ projectGroup=org.eclipse.dataspaceconnector.identityhub
 defaultVersion=0.0.1-SNAPSHOT
 
 edcGroup=org.eclipse.dataspaceconnector
-edcVersion=0.0.1-SNAPSHOT
+edcVersion=0.0.1-milestone-5
 assertj=3.22.0
 jupiterVersion=5.8.2
 storageBlobVersion=12.11.0


### PR DESCRIPTION
## What this PR changes/adds

Uses the latest EDC M5 version in local and CI builds. Removes the local checkout entirely.
ALso fixes a broken test.


## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/identityservice/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/identityservice/blob/main/styleguide.md) for details_)
