### PR TITLE
Fix broken test 

### DIFF
--- a/extensions/identity-hub-verifier/build.gradle.kts
+++ b/extensions/identity-hub-verifier/build.gradle.kts
@@ -38,7 +38,6 @@ dependencies {
     testImplementation("com.github.javafaker:javafaker:${faker}")
     testImplementation("org.assertj:assertj-core:${assertj}")
     testImplementation("org.mockito:mockito-core:${mockitoVersion}")
-    testImplementation("${edcGroup}:identity-did-core:${edcVersion}")
     testImplementation("${edcGroup}:junit:${edcVersion}")
     testImplementation("org.junit.jupiter:junit-jupiter-api:${jupiterVersion}")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:${jupiterVersion}")

--- a/extensions/identity-hub-verifier/src/test/java/org/eclipse/dataspaceconnector/identityhub/verifier/CredentialsVerifierExtensionTest.java
+++ b/extensions/identity-hub-verifier/src/test/java/org/eclipse/dataspaceconnector/identityhub/verifier/CredentialsVerifierExtensionTest.java
@@ -16,7 +16,6 @@ package org.eclipse.dataspaceconnector.identityhub.verifier;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.javafaker.Faker;
-import org.eclipse.dataspaceconnector.iam.did.resolution.DidPublicKeyResolverImpl;
 import org.eclipse.dataspaceconnector.iam.did.spi.credentials.CredentialsVerifier;
 import org.eclipse.dataspaceconnector.iam.did.spi.document.DidDocument;
 import org.eclipse.dataspaceconnector.iam.did.spi.document.Service;
@@ -42,7 +41,6 @@ import static org.eclipse.dataspaceconnector.identityhub.junit.testfixtures.Veri
 import static org.eclipse.dataspaceconnector.identityhub.junit.testfixtures.VerifiableCredentialTestUtil.toPublicKeyWrapper;
 import static org.eclipse.dataspaceconnector.junit.testfixtures.TestUtils.getFreePort;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(EdcExtension.class)
@@ -53,21 +51,18 @@ public class CredentialsVerifierExtensionTest {
     private static final String CREDENTIAL_ISSUER = FAKER.internet().url();
     private static final String SUBJECT = FAKER.internet().url();
     private IdentityHubClient identityHubClient;
-    private DidPublicKeyResolver publicKeyResolver;
 
     @BeforeEach
     void setUp(EdcExtension extension) {
         identityHubClient = new IdentityHubClientImpl(TestUtils.testOkHttpClient(), new ObjectMapper(), new ConsoleMonitor());
-        publicKeyResolver = mock(DidPublicKeyResolverImpl.class);
-        extension.registerServiceMock(DidPublicKeyResolver.class, publicKeyResolver);
         extension.setConfiguration(Map.of("web.http.port", String.valueOf(PORT)));
     }
 
     @Test
-    public void getVerifiedClaims_getValidClaims(CredentialsVerifier verifier) {
+    public void getVerifiedClaims_getValidClaims(CredentialsVerifier verifier, DidPublicKeyResolver mockResolver) {
         // Arrange
         var jwk = generateEcKey();
-        when(publicKeyResolver.resolvePublicKey(anyString())).thenReturn(Result.success(toPublicKeyWrapper(jwk)));
+        when(mockResolver.resolvePublicKey(anyString())).thenReturn(Result.success(toPublicKeyWrapper(jwk)));
         var didDocument = DidDocument.Builder.newInstance()
                 .id(SUBJECT)
                 .service(List.of(new Service("IdentityHub", "IdentityHub", API_URL)))

--- a/extensions/identity-hub-verifier/src/test/java/org/eclipse/dataspaceconnector/identityhub/verifier/MockDidPublicKeyResolverExtension.java
+++ b/extensions/identity-hub-verifier/src/test/java/org/eclipse/dataspaceconnector/identityhub/verifier/MockDidPublicKeyResolverExtension.java
@@ -1,0 +1,32 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.identityhub.mock;
+
+import org.eclipse.dataspaceconnector.iam.did.spi.resolution.DidPublicKeyResolver;
+import org.eclipse.dataspaceconnector.spi.system.Provider;
+import org.eclipse.dataspaceconnector.spi.system.ServiceExtension;
+
+import static org.mockito.Mockito.mock;
+
+/**
+ * Extension to provide a mock implementation of {@link DidPublicKeyResolver} for testing.
+ */
+public class MockDidPublicKeyResolverExtension implements ServiceExtension {
+
+    @Provider
+    public DidPublicKeyResolver didPublicKeyResolver() {
+        return mock(DidPublicKeyResolver.class);
+    }
+}

--- a/extensions/identity-hub-verifier/src/test/resources/META-INF/services/org.eclipse.dataspaceconnector.spi.system.ServiceExtension
+++ b/extensions/identity-hub-verifier/src/test/resources/META-INF/services/org.eclipse.dataspaceconnector.spi.system.ServiceExtension
@@ -1,0 +1,1 @@
+org.eclipse.dataspaceconnector.identityhub.mock.MockDidPublicKeyResolverExtension


### PR DESCRIPTION
## What this PR changes/adds

Fix broken CredentialsVerifierExtensionTest by introducing a new MockDidPublicKeyResolverExtension to provide a mock for DidPublicKeyResolver.

## Why it does that

CredentialsVerifierExtensionTest is broken due to unstable DI mechanism

## Linked Issue(s)

Relates to #21
