### PR TITLE
Add Self-Description endpoint (#37)

### DIFF
--- a/client-cli/src/main/java/org/eclipse/dataspaceconnector/identityhub/cli/GetSelfDescriptionCommand.java
+++ b/client-cli/src/main/java/org/eclipse/dataspaceconnector/identityhub/cli/GetSelfDescriptionCommand.java
@@ -1,0 +1,52 @@
+/*
+ *  Copyright (c) 2022 Amadeus
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Amadeus - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.identityhub.cli;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.ParentCommand;
+
+import java.util.concurrent.Callable;
+
+
+@Command(name = "get", description = "Display Self-Description document.")
+class GetSelfDescriptionCommand implements Callable<Integer> {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper()
+            .enable(SerializationFeature.INDENT_OUTPUT);
+
+    @ParentCommand
+    SelfDescriptionCommand command;
+
+    @CommandLine.Spec
+    private CommandLine.Model.CommandSpec spec;
+
+    @Override
+    public Integer call() throws Exception {
+        var out = spec.commandLine().getOut();
+        var result = command.cli.identityHubClient.getSelfDescription(command.cli.hubUrl);
+        if (result.failed()) {
+            throw new CliException("Error while getting Self-Description: " + result.getFailureDetail());
+        }
+
+        MAPPER.writeValue(out, result.getContent());
+        out.println();
+        return 0;
+    }
+}
+
+

--- a/client-cli/src/main/java/org/eclipse/dataspaceconnector/identityhub/cli/IdentityHubCli.java
+++ b/client-cli/src/main/java/org/eclipse/dataspaceconnector/identityhub/cli/IdentityHubCli.java
@@ -27,7 +27,8 @@ import picocli.CommandLine.Command;
 @Command(name = "identity-hub-cli", mixinStandardHelpOptions = true,
         description = "Client utility for MVD identity hub.",
         subcommands = {
-                VerifiableCredentialsCommand.class
+                VerifiableCredentialsCommand.class,
+                SelfDescriptionCommand.class
         })
 public class IdentityHubCli {
     @CommandLine.Option(names = { "-s", "--identity-hub-url" }, required = true, description = "Identity Hub URL", defaultValue = "http://localhost:8181/api/identity-hub")

--- a/client-cli/src/main/java/org/eclipse/dataspaceconnector/identityhub/cli/SelfDescriptionCommand.java
+++ b/client-cli/src/main/java/org/eclipse/dataspaceconnector/identityhub/cli/SelfDescriptionCommand.java
@@ -1,0 +1,28 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.identityhub.cli;
+
+import picocli.CommandLine.Command;
+import picocli.CommandLine.ParentCommand;
+
+@Command(name = "sd", mixinStandardHelpOptions = true,
+        description = "Manage Self-Description.",
+        subcommands = {
+                GetSelfDescriptionCommand.class,
+        })
+class SelfDescriptionCommand {
+    @ParentCommand
+    IdentityHubCli cli;
+}

--- a/extensions/identity-hub-verifier/src/main/java/org/eclipse/dataspaceconnector/identityhub/verifier/CredentialsVerifierExtension.java
+++ b/extensions/identity-hub-verifier/src/main/java/org/eclipse/dataspaceconnector/identityhub/verifier/CredentialsVerifierExtension.java
@@ -16,21 +16,17 @@ package org.eclipse.dataspaceconnector.identityhub.verifier;
 
 import okhttp3.OkHttpClient;
 import org.eclipse.dataspaceconnector.iam.did.spi.credentials.CredentialsVerifier;
-import org.eclipse.dataspaceconnector.iam.did.spi.resolution.DidPublicKeyResolver;
 import org.eclipse.dataspaceconnector.identityhub.client.IdentityHubClientImpl;
 import org.eclipse.dataspaceconnector.identityhub.credentials.VerifiableCredentialsJwtServiceImpl;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.system.Inject;
 import org.eclipse.dataspaceconnector.spi.system.Provider;
-import org.eclipse.dataspaceconnector.spi.system.Requires;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtension;
-import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
 import org.eclipse.dataspaceconnector.spi.types.TypeManager;
 
 /**
- * Extension to provide verification of IdentityHub Verifiable Credentials.
+ * Extension to provide verifier for IdentityHub Verifiable Credentials.
  */
-@Requires({ DidPublicKeyResolver.class })
 public class CredentialsVerifierExtension implements ServiceExtension {
 
     @Inject
@@ -45,26 +41,13 @@ public class CredentialsVerifierExtension implements ServiceExtension {
     @Inject
     private JwtCredentialsVerifier jwtCredentialsVerifier;
 
-    private DidPublicKeyResolver didPublicKeyResolver;
-
     @Override
-    public void initialize(ServiceExtensionContext context) {
-        monitor.info("Initialized Identity Hub DID extension");
-    }
-
-    @Provider(isDefault = true)
-    public JwtCredentialsVerifier createJwtVerifier(ServiceExtensionContext context) {
-        // Lazy instantiation of DidPublicKeyResolver to prevent injection issues. As the same extension is providing and requiring JwtCredentialsVerifier,
-        // while resolving the @Inject the provider method gets called, at which point the (if also injected) DidPublicKeyResolver might still be null, because it's not yet resolved.
-        if (didPublicKeyResolver == null) {
-            didPublicKeyResolver = context.getService(DidPublicKeyResolver.class);
-        }
-        Monitor monitor = context.getService(Monitor.class);
-        return new DidJwtCredentialsVerifier(didPublicKeyResolver, monitor);
+    public String name() {
+        return "Credentials Verifier";
     }
 
     @Provider
-    public CredentialsVerifier createCredentialsVerifier(ServiceExtensionContext context) {
+    public CredentialsVerifier createCredentialsVerifier() {
         var client = new IdentityHubClientImpl(httpClient, typeManager.getMapper(), monitor);
         var verifiableCredentialsJwtService = new VerifiableCredentialsJwtServiceImpl(typeManager.getMapper(), monitor);
         return new IdentityHubCredentialsVerifier(client, monitor, jwtCredentialsVerifier, verifiableCredentialsJwtService);

--- a/extensions/identity-hub-verifier/src/main/java/org/eclipse/dataspaceconnector/identityhub/verifier/JwtCredentialsVerifierExtension.java
+++ b/extensions/identity-hub-verifier/src/main/java/org/eclipse/dataspaceconnector/identityhub/verifier/JwtCredentialsVerifierExtension.java
@@ -1,0 +1,41 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.identityhub.verifier;
+
+import org.eclipse.dataspaceconnector.iam.did.spi.resolution.DidPublicKeyResolver;
+import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
+import org.eclipse.dataspaceconnector.spi.system.Inject;
+import org.eclipse.dataspaceconnector.spi.system.Provider;
+import org.eclipse.dataspaceconnector.spi.system.ServiceExtension;
+
+/**
+ * Extension to provide verifier for IdentityHub Verifiable Credentials in JWT format.
+ */
+public class JwtCredentialsVerifierExtension implements ServiceExtension {
+    @Inject
+    private Monitor monitor;
+    @Inject
+    private DidPublicKeyResolver didPublicKeyResolver;
+
+    @Override
+    public String name() {
+        return "JWT Credentials Verifier";
+    }
+
+    @Provider
+    public JwtCredentialsVerifier createJwtVerifier() {
+        return new DidJwtCredentialsVerifier(didPublicKeyResolver, monitor);
+    }
+}

--- a/extensions/identity-hub-verifier/src/main/resources/META-INF/services/org.eclipse.dataspaceconnector.spi.system.ServiceExtension
+++ b/extensions/identity-hub-verifier/src/main/resources/META-INF/services/org.eclipse.dataspaceconnector.spi.system.ServiceExtension
@@ -1,1 +1,2 @@
 org.eclipse.dataspaceconnector.identityhub.verifier.CredentialsVerifierExtension
+org.eclipse.dataspaceconnector.identityhub.verifier.JwtCredentialsVerifierExtension

--- a/extensions/identity-hub-verifier/src/test/java/org/eclipse/dataspaceconnector/identityhub/verifier/DidJwtCredentialsVerifierTest.java
+++ b/extensions/identity-hub-verifier/src/test/java/org/eclipse/dataspaceconnector/identityhub/verifier/DidJwtCredentialsVerifierTest.java
@@ -23,6 +23,7 @@ import org.eclipse.dataspaceconnector.iam.did.spi.resolution.DidPublicKeyResolve
 import org.eclipse.dataspaceconnector.identityhub.junit.testfixtures.VerifiableCredentialTestUtil;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.result.Result;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.text.ParseException;
@@ -41,7 +42,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
-public class DidJwtCredentialsVerifierTest {
+class DidJwtCredentialsVerifierTest {
 
     private static final Faker FAKER = new Faker();
     private static final ECKey JWK = generateEcKey();
@@ -50,11 +51,18 @@ public class DidJwtCredentialsVerifierTest {
     private static final String SUBJECT = FAKER.internet().url();
     private static final String OTHER_SUBJECT = FAKER.internet().url() + "other";
     private static final SignedJWT JWT = buildSignedJwt(generateVerifiableCredential(), ISSUER, SUBJECT, JWK);
-    private DidPublicKeyResolver didPublicKeyResolver = mock(DidPublicKeyResolver.class);
-    private DidJwtCredentialsVerifier didJwtCredentialsVerifier = new DidJwtCredentialsVerifier(didPublicKeyResolver, mock(Monitor.class));
+    private DidPublicKeyResolver didPublicKeyResolver;
+    private DidJwtCredentialsVerifier didJwtCredentialsVerifier;
+
+    @BeforeEach
+    public void setUp() {
+        didPublicKeyResolver = mock(DidPublicKeyResolver.class);
+        didJwtCredentialsVerifier = new DidJwtCredentialsVerifier(didPublicKeyResolver, mock(Monitor.class));
+    }
+
 
     @Test
-    public void isSignedByIssuer_jwtSignedByIssuer() {
+    void isSignedByIssuer_jwtSignedByIssuer() {
 
         // Arrange
         when(didPublicKeyResolver.resolvePublicKey(ISSUER)).thenReturn(Result.success(toPublicKeyWrapper(JWK)));
@@ -64,7 +72,7 @@ public class DidJwtCredentialsVerifierTest {
     }
 
     @Test
-    public void isSignedByIssuer_jwtSignedByWrongIssuer() {
+    void isSignedByIssuer_jwtSignedByWrongIssuer() {
 
         // Arrange
         when(didPublicKeyResolver.resolvePublicKey(ISSUER)).thenReturn(Result.success(toPublicKeyWrapper(ANOTHER_JWK)));
@@ -74,7 +82,7 @@ public class DidJwtCredentialsVerifierTest {
     }
 
     @Test
-    public void isSignedByIssuer_PublicKeyCantBeResolved() {
+    void isSignedByIssuer_PublicKeyCantBeResolved() {
 
         // Arrange
         when(didPublicKeyResolver.resolvePublicKey(ISSUER)).thenReturn(Result.failure("Failed resolving public key"));
@@ -84,7 +92,7 @@ public class DidJwtCredentialsVerifierTest {
     }
 
     @Test
-    public void isSignedByIssuer_issuerDidCantBeResolved() throws ParseException {
+    void isSignedByIssuer_issuerDidCantBeResolved() throws ParseException {
 
         // Arrange
         when(didPublicKeyResolver.resolvePublicKey(JWT.getJWTClaimsSet().getIssuer())).thenReturn(Result.failure(FAKER.lorem().sentence()));
@@ -94,7 +102,7 @@ public class DidJwtCredentialsVerifierTest {
     }
 
     @Test
-    public void isSignedByIssuer_cantParsePayload() throws Exception {
+    void isSignedByIssuer_cantParsePayload() throws Exception {
 
         // Arrange
         var jws = mock(SignedJWT.class);
@@ -127,7 +135,7 @@ public class DidJwtCredentialsVerifierTest {
     }
 
     @Test
-    public void verifyClaims_OnInvalidJwt() throws Exception {
+    void verifyClaims_OnInvalidJwt() throws Exception {
         // Arrange
         var jwt = mock(SignedJWT.class);
         var message = FAKER.lorem().sentence();
@@ -145,7 +153,7 @@ public class DidJwtCredentialsVerifierTest {
                 .expirationTime(from(now().plus(1, DAYS)))
                 .build();
 
-        SignedJWT jwt = VerifiableCredentialTestUtil.buildSignedJwt(claims, JWK);
+        var jwt = VerifiableCredentialTestUtil.buildSignedJwt(claims, JWK);
 
         assertThat(didJwtCredentialsVerifier.verifyClaims(jwt, SUBJECT).succeeded()).isTrue();
     }
@@ -158,7 +166,7 @@ public class DidJwtCredentialsVerifierTest {
                 .expirationTime(from(now().minus(1, DAYS)))
                 .build();
 
-        SignedJWT jwt = VerifiableCredentialTestUtil.buildSignedJwt(claims, JWK);
+        var jwt = VerifiableCredentialTestUtil.buildSignedJwt(claims, JWK);
 
         assertThat(didJwtCredentialsVerifier.verifyClaims(jwt, SUBJECT).failed()).isTrue();
     }
@@ -171,7 +179,7 @@ public class DidJwtCredentialsVerifierTest {
                 .notBeforeTime(from(now().minus(1, DAYS)))
                 .build();
 
-        SignedJWT jwt = VerifiableCredentialTestUtil.buildSignedJwt(claims, JWK);
+        var jwt = VerifiableCredentialTestUtil.buildSignedJwt(claims, JWK);
 
         assertThat(didJwtCredentialsVerifier.verifyClaims(jwt, SUBJECT).succeeded()).isTrue();
     }
@@ -184,7 +192,7 @@ public class DidJwtCredentialsVerifierTest {
                 .notBeforeTime(from(now().plus(1, DAYS)))
                 .build();
 
-        SignedJWT jwt = VerifiableCredentialTestUtil.buildSignedJwt(claims, JWK);
+        var jwt = VerifiableCredentialTestUtil.buildSignedJwt(claims, JWK);
 
         assertThat(didJwtCredentialsVerifier.verifyClaims(jwt, SUBJECT).failed()).isTrue();
     }

--- a/extensions/identity-hub-verifier/src/test/java/org/eclipse/dataspaceconnector/identityhub/verifier/IdentityHubCredentialsVerifierTest.java
+++ b/extensions/identity-hub-verifier/src/test/java/org/eclipse/dataspaceconnector/identityhub/verifier/IdentityHubCredentialsVerifierTest.java
@@ -44,11 +44,10 @@ import static org.eclipse.dataspaceconnector.identityhub.junit.testfixtures.Veri
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-public class IdentityHubCredentialsVerifierTest {
+class IdentityHubCredentialsVerifierTest {
 
     private static final Faker FAKER = new Faker();
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
@@ -57,14 +56,14 @@ public class IdentityHubCredentialsVerifierTest {
             .service(List.of(new Service("IdentityHub", "IdentityHub", HUB_BASE_URL))).build();
     private static final String ISSUER = FAKER.internet().url();
     private static final String SUBJECT = FAKER.internet().url();
-    private Monitor monitorMock = mock(Monitor.class);
-    private IdentityHubClient identityHubClientMock = mock(IdentityHubClient.class);
-    private JwtCredentialsVerifier jwtCredentialsVerifierMock = mock(JwtCredentialsVerifier.class);
-    private VerifiableCredentialsJwtServiceImpl verifiableCredentialsJwtService = new VerifiableCredentialsJwtServiceImpl(OBJECT_MAPPER, monitorMock);
-    private CredentialsVerifier credentialsVerifier = new IdentityHubCredentialsVerifier(identityHubClientMock, monitorMock, jwtCredentialsVerifierMock, verifiableCredentialsJwtService);
+    private final Monitor monitorMock = mock(Monitor.class);
+    private final IdentityHubClient identityHubClientMock = mock(IdentityHubClient.class);
+    private final JwtCredentialsVerifier jwtCredentialsVerifierMock = mock(JwtCredentialsVerifier.class);
+    private final VerifiableCredentialsJwtServiceImpl verifiableCredentialsJwtService = new VerifiableCredentialsJwtServiceImpl(OBJECT_MAPPER, monitorMock);
+    private final CredentialsVerifier credentialsVerifier = new IdentityHubCredentialsVerifier(identityHubClientMock, monitorMock, jwtCredentialsVerifierMock, verifiableCredentialsJwtService);
 
     @Test
-    public void getVerifiedClaims_getValidClaims() {
+    void getVerifiedClaims_getValidClaims() {
 
         // Arrange
         var credential = generateVerifiableCredential();
@@ -88,7 +87,7 @@ public class IdentityHubCredentialsVerifierTest {
     }
 
     @Test
-    public void getVerifiedClaims_filtersSignedByWrongIssuer() {
+    void getVerifiedClaims_filtersSignedByWrongIssuer() {
 
         // Arrange
         var credential = generateVerifiableCredential();
@@ -103,7 +102,7 @@ public class IdentityHubCredentialsVerifierTest {
     }
 
     @Test
-    public void getVerifiedClaims_hubUrlNotResolved() {
+    void getVerifiedClaims_hubUrlNotResolved() {
         // Arrange
         var didDocument = DidDocument.Builder.newInstance().build();
 
@@ -116,7 +115,7 @@ public class IdentityHubCredentialsVerifierTest {
     }
 
     @Test
-    public void getVerifiedClaims_idHubCallFails() {
+    void getVerifiedClaims_idHubCallFails() {
 
         // Arrange
         when(identityHubClientMock.getVerifiableCredentials(HUB_BASE_URL)).thenReturn(StatusResult.failure(ResponseStatus.FATAL_ERROR));
@@ -129,7 +128,7 @@ public class IdentityHubCredentialsVerifierTest {
     }
 
     @Test
-    public void getVerifiedClaims_verifiableCredentialsWithWrongFormat() {
+    void getVerifiedClaims_verifiableCredentialsWithWrongFormat() {
 
         // Arrange
         var jws = new SignedJWT(new JWSHeader.Builder(JWSAlgorithm.ES256).build(), new JWTClaimsSet.Builder().build());
@@ -140,11 +139,11 @@ public class IdentityHubCredentialsVerifierTest {
 
         // Assert
         assertThat(credentials.failed()).isTrue();
-        verify(monitorMock, times(1)).severe(ArgumentMatchers.<Supplier<String>>any());
+        verify(monitorMock).severe(ArgumentMatchers.<Supplier<String>>any());
     }
 
     @Test
-    public void getVerifiedClaims_verifiableCredentialsWithMissingId() {
+    void getVerifiedClaims_verifiableCredentialsWithMissingId() {
 
         // Arrange
         var jwsHeader = new JWSHeader.Builder(JWSAlgorithm.ES256).build();
@@ -161,7 +160,7 @@ public class IdentityHubCredentialsVerifierTest {
 
         // Assert
         assertThat(credentials.failed()).isTrue();
-        verify(monitorMock, times(1)).severe(ArgumentMatchers.<Supplier<String>>any());
+        verify(monitorMock).severe(ArgumentMatchers.<Supplier<String>>any());
     }
 
 }

--- a/extensions/identity-hub/build.gradle.kts
+++ b/extensions/identity-hub/build.gradle.kts
@@ -24,6 +24,7 @@ val jupiterVersion: String by project
 val restAssured: String by project
 val faker: String by project
 val nimbusVersion: String by project
+val mockitoVersion: String by project
 
 dependencies {
     api(project(":spi:identity-hub-spi"))
@@ -39,6 +40,7 @@ dependencies {
     testImplementation("org.assertj:assertj-core:${assertj}")
     testImplementation("io.rest-assured:rest-assured:${restAssured}")
     testImplementation("com.github.javafaker:javafaker:${faker}")
+    testImplementation("org.mockito:mockito-core:${mockitoVersion}")
     testImplementation(testFixtures(project(":spi:identity-hub-spi")))
 }
 

--- a/extensions/identity-hub/src/main/java/org/eclipse/dataspaceconnector/identityhub/api/IdentityHubController.java
+++ b/extensions/identity-hub/src/main/java/org/eclipse/dataspaceconnector/identityhub/api/IdentityHubController.java
@@ -14,12 +14,15 @@
 
 package org.eclipse.dataspaceconnector.identityhub.api;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
 import jakarta.ws.rs.POST;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
 import org.eclipse.dataspaceconnector.identityhub.model.MessageRequestObject;
 import org.eclipse.dataspaceconnector.identityhub.model.MessageResponseObject;
 import org.eclipse.dataspaceconnector.identityhub.model.RequestObject;
@@ -38,15 +41,17 @@ import static org.eclipse.dataspaceconnector.identityhub.model.WebNodeInterfaceM
  * See {@link WebNodeInterfaces} for a list of currently supported DWN interfaces.
  */
 @Tag(name = "IdentityHub")
-@Produces({ "application/json" })
-@Consumes({ "application/json" })
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
 @Path("/identity-hub")
 public class IdentityHubController {
 
     private final MessageProcessorRegistry messageProcessorRegistry;
+    private final JsonNode selfDescription;
 
-    public IdentityHubController(MessageProcessorRegistry messageProcessorRegistry) {
+    public IdentityHubController(MessageProcessorRegistry messageProcessorRegistry, JsonNode selfDescription) {
         this.messageProcessorRegistry = messageProcessorRegistry;
+        this.selfDescription = selfDescription;
     }
 
     @Operation(description = "A Decentralized Web Node (https://identity.foundation/decentralized-web-node/spec) compatible endpoint supporting operations to read and write Verifiable Credentials into an Identity Hub")
@@ -62,6 +67,13 @@ public class IdentityHubController {
                 .status(RequestStatus.OK)
                 .replies(replies)
                 .build();
+    }
+
+    @Operation(description = "Serve Self-Description document as defined in Gaia-X Trust Framework (https://gaia-x.gitlab.io/policy-rules-committee/trust-framework/)")
+    @GET
+    @Path("/self-description")
+    public JsonNode getSelfDescription() {
+        return selfDescription;
     }
 
     private MessageResponseObject processMessage(MessageRequestObject messageRequestObject) {

--- a/extensions/identity-hub/src/main/java/org/eclipse/dataspaceconnector/identityhub/selfdescription/SelfDescriptionLoader.java
+++ b/extensions/identity-hub/src/main/java/org/eclipse/dataspaceconnector/identityhub/selfdescription/SelfDescriptionLoader.java
@@ -1,0 +1,66 @@
+/*
+ *  Copyright (c) 2022 Amadeus
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Amadeus - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.identityhub.selfdescription;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.eclipse.dataspaceconnector.spi.EdcException;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
+
+import static java.lang.String.format;
+
+public class SelfDescriptionLoader {
+
+    private final ObjectMapper mapper;
+
+    public SelfDescriptionLoader(ObjectMapper mapper) {
+        this.mapper = mapper;
+    }
+
+    /**
+     * Load Self-Description from a provided file path.
+     *
+     * @param path Path to the Self-Description to be loaded.
+     * @return JSON representation of the Self-Description.
+     */
+    public JsonNode fromFile(String path) {
+        try (var is = Files.newInputStream(Path.of(path))) {
+            return mapper.readTree(is);
+        } catch (IOException e) {
+            throw new EdcException(e);
+        }
+    }
+
+    /**
+     * Load Self-Description from the classpath.
+     *
+     * @param fileName Name of the classpath file from which Self-Description will be loaded.
+     * @return JSON representation of the Self-Description.
+     */
+    public JsonNode fromClasspath(String fileName) {
+        try (var is = this.getClass().getClassLoader().getResourceAsStream(fileName)) {
+            if (is == null) {
+                throw new NoSuchFileException(format("Cannot find file `%s` from classpath", fileName));
+            }
+            return mapper.readTree(is);
+        } catch (IOException e) {
+            throw new EdcException(e);
+        }
+    }
+}

--- a/extensions/identity-hub/src/main/resources/default-self-description.json
+++ b/extensions/identity-hub/src/main/resources/default-self-description.json
@@ -1,0 +1,69 @@
+{
+  "selfDescriptionCredential": {
+    "@context": [
+      "http://www.w3.org/ns/shacl#",
+      "http://www.w3.org/2001/XMLSchema#",
+      "http://w3id.org/gaia-x/participant#"
+    ],
+    "@id": "http://example.org/participant-dp6gtq7i75lmk9p4j2tfg",
+    "@type": [
+      "VerifiableCredential",
+      "LegalPerson"
+    ],
+    "credentialSubject": {
+      "id": "did:web:example.com",
+      "gx-participant:registrationNumber": {
+        "@type": "xsd:string",
+        "@value": "DEANY1234NUMBER"
+      },
+      "gx-participant:headquarterAddress": {
+        "@type": "gx-participant:Address",
+        "gx-participant:country": {
+          "@type": "xsd:string",
+          "@value": "FR"
+        }
+      },
+      "gx-participant:legalAddress": {
+        "@type": "gx-participant:Address",
+        "gx-participant:country": {
+          "@type": "xsd:string",
+          "@value": "FR"
+        }
+      },
+      "gx-participant:note": {
+        "@value": "Test Self Description signed by deltaDAO for the Gaia-X Hackathon #4",
+        "@type": "xsd:string"
+      }
+    },
+    "proof": {
+      "type": "JsonWebKey2020",
+      "created": "2022-06-21T11:47:23.802Z",
+      "proofPurpose": "assertionMethod",
+      "verificationMethod": "did:web:test.delta-dao.com",
+      "jws": "eyJhbGciOiJQUzI1NiIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..2bSfloq1nDSLL45R-RTx_dYzwrE7C2XRCelTG78rORNXueTgrI1wchuUAI18R4_dIJgVpYiwMU_xnSAYgPXvfREZAK9-qbQc0lpzpVgDaVwhoI7N_TPIeSPd_3zwDSy4W8LTGAXt9nTAwQJfH-qwsV6kRqN1To0p-VqdnZda2IWf_2Mxdu2cYFm9mGT9RCoACCqwdkBR44PIP3lt-pGM68_pxfj3TNiAAcYj8fWucSkoeA_tSZV7Z5YNxa-Ge6j4DbpNADOBUYgmKeU0zIvPEi4UGYiFgeiM7F9u3-v_0VQ3ODuBcprQYIbgL0_7YN6QwUlZBfpeXXXvG7LmQGbibw"
+    }
+  },
+  "complianceCredential": {
+    "@context": [
+      "https://www.w3.org/2018/credentials/v1"
+    ],
+    "@type": [
+      "VerifiableCredential",
+      "ParticipantCredential"
+    ],
+    "id": "https://catalogue.gaia-x.eu/credentials/ParticipantCredential/1655812045129",
+    "issuer": "did:web:compliance.gaia-x.eu",
+    "issuanceDate": "2022-06-21T11:47:25.129Z",
+    "credentialSubject": {
+      "id": "did:web:example.com",
+      "hash": "f5b874c2091b79b0536aa1afb12b599ee0b0b48c90667e9bf6161846f29eb765"
+    },
+    "proof": {
+      "type": "JsonWebKey2020",
+      "created": "2022-06-21T11:47:25.129Z",
+      "proofPurpose": "assertionMethod",
+      "jws": "eyJhbGciOiJQUzI1NiIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..YQndX4X4oUE2_dU0dkIU1CA36Y9PlIaB5-duDj6QXRCNTa7aZ_sLVmsaHetj7xk4ghHztuiSONaDfg_JV-EYQrf3OFlKxxcrUzUcpaswekIgAAvoWei-eS0DZ2tVbA3aCaDxUS5CGoKRNdv5yive_oWcPtlrPnflpOSHXspBnrry1BKLrkfBzt45LPDvt56E_UGjAcPnMe4ANT8GWbwb5hujLkZcnhFSKnGv8OlcRbFWNLz9QM8nBSXc2PM-Yrbz1odbrJ7DnX_wpOwapW-ZKu6xPLT-OV--gsZU__jscgxSGdrci_qX3TYc8_Ahs2YCI2aFfOEKlDl4nLYcA51BtQ",
+      "verificationMethod": "did:web:compliance.gaia-x.eu"
+    }
+  }
+}

--- a/extensions/identity-hub/src/test/java/org/eclipse/dataspaceconnector/identityhub/api/IdentityHubControllerTest.java
+++ b/extensions/identity-hub/src/test/java/org/eclipse/dataspaceconnector/identityhub/api/IdentityHubControllerTest.java
@@ -46,7 +46,7 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 
 @ExtendWith(EdcExtension.class)
-public class IdentityHubControllerTest {
+class IdentityHubControllerTest {
 
     private static final int PORT = getFreePort();
     private static final String API_URL = String.format("http://localhost:%s/api", PORT);
@@ -55,13 +55,15 @@ public class IdentityHubControllerTest {
     private static final String TARGET = FAKER.internet().url();
     private static final String REQUEST_ID = FAKER.internet().uuid();
 
+    private static final String BASE_PATH = "/identity-hub";
+
     @BeforeEach
     void setUp(EdcExtension extension) {
         extension.setConfiguration(Map.of("web.http.port", String.valueOf(PORT)));
     }
 
     @Test
-    void writeAndQueryObject() throws Exception {
+    void writeAndQueryObject() {
         // Arrange
         var issuer = FAKER.internet().url();
         var subject = FAKER.internet().url();
@@ -117,10 +119,22 @@ public class IdentityHubControllerTest {
                 .body("replies[0].status.detail", equalTo("The message was malformed or improperly constructed"));
     }
 
+    @Test
+    void getSelfDescription() {
+        given()
+                .baseUri(API_URL)
+                .basePath(BASE_PATH)
+                .get("/self-description")
+                .then()
+                .assertThat()
+                .statusCode(200)
+                .body("selfDescriptionCredential.credentialSubject.gx-participant:headquarterAddress.gx-participant:country.@value", equalTo("FR"));
+    }
+
     private RequestSpecification baseRequest() {
         return given()
                 .baseUri(API_URL)
-                .basePath("/identity-hub")
+                .basePath(BASE_PATH)
                 .contentType(JSON)
                 .when();
     }

--- a/extensions/identity-hub/src/test/java/org/eclipse/dataspaceconnector/identityhub/selfdescription/SelfDescriptionLoaderTest.java
+++ b/extensions/identity-hub/src/test/java/org/eclipse/dataspaceconnector/identityhub/selfdescription/SelfDescriptionLoaderTest.java
@@ -1,0 +1,78 @@
+/*
+ *  Copyright (c) 2022 Amadeus
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Amadeus - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.identityhub.selfdescription;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.eclipse.dataspaceconnector.spi.EdcException;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+class SelfDescriptionLoaderTest {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    private final SelfDescriptionLoader loader = new SelfDescriptionLoader(OBJECT_MAPPER);
+
+    @Test
+    void fromFile() throws IOException {
+        var path = "src/test/resources/self-description.json";
+        var expected = loadJsonFile(path);
+
+        var result = loader.fromFile(path);
+
+        assertThat(result).usingRecursiveFieldByFieldElementComparator().isEqualTo(expected);
+    }
+
+    @Test
+    void fromFile_fileNotFound() {
+        assertThatExceptionOfType(EdcException.class).isThrownBy(() -> loader.fromFile("src/test/resources/invalid-self-description.json"))
+                .withRootCauseExactlyInstanceOf(NoSuchFileException.class);
+    }
+
+    @Test
+    void fromFile_invalidJson() {
+        assertThatExceptionOfType(EdcException.class).isThrownBy(() -> loader.fromFile("src/test/resources/invalid-self-description.txt"))
+                .withRootCauseExactlyInstanceOf(JsonParseException.class);
+    }
+
+    @Test
+    void fromClasspath() throws IOException {
+        var expected = loadJsonFile("src/main/resources/default-self-description.json");
+
+        var result = loader.fromClasspath("default-self-description.json");
+
+        assertThat(result).usingRecursiveFieldByFieldElementComparator().isEqualTo(expected);
+    }
+
+    @Test
+    void fromClasspath_fileNotFound() {
+        assertThatExceptionOfType(EdcException.class).isThrownBy(() -> loader.fromClasspath("default-self-descriptionxx.json"))
+                .withRootCauseExactlyInstanceOf(NoSuchFileException.class);
+    }
+
+    private static JsonNode loadJsonFile(String path) throws IOException {
+        var content = Files.readString(Path.of(path));
+        return OBJECT_MAPPER.readTree(content);
+    }
+}

--- a/extensions/identity-hub/src/test/resources/invalid-self-description.txt
+++ b/extensions/identity-hub/src/test/resources/invalid-self-description.txt
@@ -1,0 +1,1 @@
+hello-world

--- a/extensions/identity-hub/src/test/resources/self-description.json
+++ b/extensions/identity-hub/src/test/resources/self-description.json
@@ -1,0 +1,46 @@
+{
+  "selfDescriptionCredential": {
+    "@context": [
+      "http://www.w3.org/ns/shacl#",
+      "http://www.w3.org/2001/XMLSchema#",
+      "http://w3id.org/gaia-x/participant#"
+    ],
+    "@id": "http://example.org/participant-dp6gtq7i75lmk9p4j2tfg",
+    "@type": [
+      "VerifiableCredential",
+      "LegalPerson"
+    ],
+    "credentialSubject": {
+      "id": "did:web:example.com",
+      "gx-participant:registrationNumber": {
+        "@type": "xsd:string",
+        "@value": "HELLOWORLD"
+      },
+      "gx-participant:headquarterAddress": {
+        "@type": "gx-participant:Address",
+        "gx-participant:country": {
+          "@type": "xsd:string",
+          "@value": "DE"
+        }
+      },
+      "gx-participant:legalAddress": {
+        "@type": "gx-participant:Address",
+        "gx-participant:country": {
+          "@type": "xsd:string",
+          "@value": "DE"
+        }
+      },
+      "gx-participant:note": {
+        "@value": "A random self-description",
+        "@type": "xsd:string"
+      }
+    },
+    "proof": {
+      "type": "JsonWebKey2020",
+      "created": "2022-06-21T11:47:23.802Z",
+      "proofPurpose": "assertionMethod",
+      "verificationMethod": "did:web:test.delta-dao.com",
+      "jws": "eyJhbGciOiJQUzI1NiIsImI2NCI6ZmFsc2UsImNyaXQiOlsiYjY0Il19..2bSfloq1nDSLL45R-RTx_dYzwrE7C2XRCelTG78rORNXueTgrI1wchuUAI18R4_dIJgVpYiwMU_xnSAYgPXvfREZAK9-qbQc0lpzpVgDaVwhoI7N_TPIeSPd_3zwDSy4W8LTGAXt9nTAwQJfH-qwsV6kRqN1To0p-VqdnZda2IWf_2Mxdu2cYFm9mGT9RCoACCqwdkBR44PIP3lt-pGM68_pxfj3TNiAAcYj8fWucSkoeA_tSZV7Z5YNxa-Ge6j4DbpNADOBUYgmKeU0zIvPEi4UGYiFgeiM7F9u3-v_0VQ3ODuBcprQYIbgL0_7YN6QwUlZBfpeXXXvG7LmQGbibw"
+    }
+  }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ projectGroup=org.eclipse.dataspaceconnector.identityhub
 defaultVersion=0.0.1-SNAPSHOT
 
 edcGroup=org.eclipse.dataspaceconnector
-edcVersion=0.0.1-milestone-5
+edcVersion=0.0.1-milestone-5.1
 assertj=3.22.0
 jupiterVersion=5.8.2
 storageBlobVersion=12.11.0

--- a/identity-hub-core/identity-hub-client/src/main/java/org/eclipse/dataspaceconnector/identityhub/client/IdentityHubClient.java
+++ b/identity-hub-core/identity-hub-client/src/main/java/org/eclipse/dataspaceconnector/identityhub/client/IdentityHubClient.java
@@ -14,26 +14,33 @@
 
 package org.eclipse.dataspaceconnector.identityhub.client;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.nimbusds.jwt.SignedJWT;
 import org.eclipse.dataspaceconnector.spi.response.StatusResult;
 
-import java.io.IOException;
 import java.util.Collection;
 
 /**
  * IdentityHub Client
- * This client is used to call the IdentityHub endpoints in order query and write VerifiableCredentials.
+ * This client is used to call the IdentityHub endpoints in order query and write VerifiableCredentials, and display the
+ * Self-Description document.
  * Eventually, this may be expanded to handle other types of objects and operations.
  */
 public interface IdentityHubClient {
+
+    /**
+     * Display the Self-Description document.
+     *
+     * @param hubBaseUrl Base URL of the IdentityHub instance.
+     * @return status result containing the Self-Description document if request successful.
+     */
+    StatusResult<JsonNode> getSelfDescription(String hubBaseUrl);
 
     /**
      * Get VerifiableCredentials provided by an Identity Hub instance.
      *
      * @param hubBaseUrl Base URL of the IdentityHub instance.
      * @return status result containing VerifiableCredentials if request successful.
-     * @throws IOException Signaling that an I/O exception has occurred. For example during JSON serialization or when
-     *                     reaching out to the Identity Hub server.
      */
     StatusResult<Collection<SignedJWT>> getVerifiableCredentials(String hubBaseUrl);
 
@@ -43,8 +50,6 @@ public interface IdentityHubClient {
      * @param hubBaseUrl           Base URL of the IdentityHub instance.
      * @param verifiableCredential A verifiable credential to be saved.
      * @return status result.
-     * @throws IOException Signaling that an I/O exception has occurred. For example during JSON serialization or when
-     *                     reaching out to the Identity Hub server.
      */
     StatusResult<Void> addVerifiableCredential(String hubBaseUrl, SignedJWT verifiableCredential);
 

--- a/identity-hub-core/identity-hub-client/src/test/java/org/eclipse/dataspaceconnector/identityhub/client/IdentityHubClientImplIntegrationTest.java
+++ b/identity-hub-core/identity-hub-client/src/test/java/org/eclipse/dataspaceconnector/identityhub/client/IdentityHubClientImplIntegrationTest.java
@@ -25,15 +25,13 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-import java.io.IOException;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.dataspaceconnector.identityhub.junit.testfixtures.VerifiableCredentialTestUtil.buildSignedJwt;
 import static org.eclipse.dataspaceconnector.identityhub.junit.testfixtures.VerifiableCredentialTestUtil.generateEcKey;
 import static org.mockito.Mockito.mock;
 
 @ExtendWith(EdcExtension.class)
-public class IdentityHubClientImplIntegrationTest {
+class IdentityHubClientImplIntegrationTest {
 
     private static final String API_URL = "http://localhost:8181/api/identity-hub";
     private static final Faker FAKER = new Faker();
@@ -48,19 +46,27 @@ public class IdentityHubClientImplIntegrationTest {
     }
 
     @Test
-    void addAndQueryVerifiableCredentials() throws Exception {
+    void getSelfDescription() {
+        var statusResult = client.getSelfDescription(API_URL);
+
+        assertThat(statusResult.succeeded()).isTrue();
+        assertThat(statusResult.getContent().get("selfDescriptionCredential")).isNotNull();
+    }
+
+    @Test
+    void addAndQueryVerifiableCredentials() {
         var jws = buildSignedJwt(VERIFIABLE_CREDENTIAL, FAKER.internet().url(), FAKER.internet().url(), generateEcKey());
 
         addVerifiableCredential(jws);
         getVerifiableCredential(jws);
     }
 
-    private void addVerifiableCredential(SignedJWT jws) throws IOException {
+    private void addVerifiableCredential(SignedJWT jws) {
         var statusResult = client.addVerifiableCredential(API_URL, jws);
         assertThat(statusResult.succeeded()).isTrue();
     }
 
-    private void getVerifiableCredential(SignedJWT jws) throws IOException {
+    private void getVerifiableCredential(SignedJWT jws) {
         var statusResult = client.getVerifiableCredentials(API_URL);
         assertThat(statusResult.succeeded()).isTrue();
         assertThat(statusResult.getContent()).usingRecursiveFieldByFieldElementComparator().contains(jws);

--- a/resources/openapi/yaml/identity-hub.yaml
+++ b/resources/openapi/yaml/identity-hub.yaml
@@ -3,6 +3,20 @@ info:
   title: Eclipse Dataspace Connector Identity Hub
   version: 0.0.1
 paths:
+  /identity-hub/self-description:
+    get:
+      tags:
+      - IdentityHub
+      description: Serve Self-Description document as defined in Gaia-X Trust Framework
+        (https://gaia-x.gitlab.io/policy-rules-committee/trust-framework/)
+      operationId: getSelfDescription
+      responses:
+        default:
+          description: default response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/JsonNode'
   /identity-hub:
     post:
       tags:
@@ -25,6 +39,8 @@ paths:
                 $ref: '#/components/schemas/ResponseObject'
 components:
   schemas:
+    JsonNode:
+      type: object
     MessageResponseObject:
       type: object
       properties:

--- a/system-tests/tests/src/test/java/org/eclipse/dataspaceconnector/identityhub/systemtests/VerifiableCredentialsIntegrationTest.java
+++ b/system-tests/tests/src/test/java/org/eclipse/dataspaceconnector/identityhub/systemtests/VerifiableCredentialsIntegrationTest.java
@@ -53,9 +53,9 @@ class VerifiableCredentialsIntegrationTest {
                     FAKER.internet().uuid(), FAKER.lorem().word()))
             .build();
 
-    private CommandLine cmd = IdentityHubCli.getCommandLine();
-    private StringWriter out = new StringWriter();
-    private StringWriter err = new StringWriter();
+    private final CommandLine cmd = IdentityHubCli.getCommandLine();
+    private final StringWriter out = new StringWriter();
+    private final StringWriter err = new StringWriter();
 
     @BeforeEach
     void setUp(EdcExtension extension) {
@@ -73,10 +73,17 @@ class VerifiableCredentialsIntegrationTest {
         assertGetVerifiedCredentials(verifier, resolverRegistry);
     }
 
+    @Test
+    void get_self_description() {
+        int result = cmd.execute("-s", HUB_URL, "sd", "get");
+        assertThat(result).isZero();
+        assertThat(out.toString()).contains("did:web:test.delta-dao.com");
+    }
+
     private void addVerifiableCredentialWithCli() throws JsonProcessingException {
         var json = MAPPER.writeValueAsString(VC1);
         int result = cmd.execute("-s", HUB_URL, "vc", "add", "-c", json, "-i", AUTHORITY_DID, "-b", PARTICIPANT_DID, "-k", AUTHORITY_PRIVATE_KEY_PATH);
-        assertThat(result).isEqualTo(0);
+        assertThat(result).isZero();
     }
 
     private void assertGetVerifiedCredentials(CredentialsVerifier verifier, DidResolverRegistry resolverRegistry) {


### PR DESCRIPTION
## What this PR changes/adds

Adds an endpoint serving Self-Description. It also introduces the associated command in the CLI client for getting the Self-Description in the console. 

Note that the current code enables to provide a Self-Description using the setting `edc.self.description.document.path`. If this setting is omitted, then a default self-description from the classpath is loaded.

## Why it does that

See https://github.com/agera-edc/IdentityHub/issues/38.

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes https://github.com/agera-edc/IdentityHub/issues/11

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/identityservice/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/identityservice/blob/main/styleguide.md) for details_)
