### PR TITLE
IdentityHubCredentialsVerifier: Fails if one VC signature verification fails

### DIFF
--- a/extensions/identity-hub-verifier/src/main/java/org/eclipse/dataspaceconnector/identityhub/verifier/AggregatedResult.java
+++ b/extensions/identity-hub-verifier/src/main/java/org/eclipse/dataspaceconnector/identityhub/verifier/AggregatedResult.java
@@ -1,0 +1,35 @@
+/*
+ *  Copyright (c) 2022 Microsoft Corporation
+ *
+ *  This program and the accompanying materials are made available under the
+ *  terms of the Apache License, Version 2.0 which is available at
+ *  https://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  SPDX-License-Identifier: Apache-2.0
+ *
+ *  Contributors:
+ *       Microsoft Corporation - initial API and implementation
+ *
+ */
+
+package org.eclipse.dataspaceconnector.identityhub.verifier;
+
+import org.eclipse.dataspaceconnector.spi.result.AbstractResult;
+import org.eclipse.dataspaceconnector.spi.result.Failure;
+
+import java.util.List;
+
+/**
+ * A generic result type containing the result of processing plus the failures happening during the processing of the
+ * result.
+ * For example, when processing a List of objects, the processing can be successful for some objects, and unsuccessful
+ * for others.
+ * Using this class as a return type would let the client decide how to act about the failures.
+ *
+ * @param <T> Result type
+ */
+class AggregatedResult<T> extends AbstractResult<T, Failure> {
+    AggregatedResult(T successfulResult, List<String> failureMessage) {
+        super(successfulResult, failureMessage.isEmpty() ? null : new Failure(failureMessage));
+    }
+}

--- a/extensions/identity-hub-verifier/src/main/java/org/eclipse/dataspaceconnector/identityhub/verifier/DidJwtCredentialsVerifier.java
+++ b/extensions/identity-hub-verifier/src/main/java/org/eclipse/dataspaceconnector/identityhub/verifier/DidJwtCredentialsVerifier.java
@@ -43,6 +43,7 @@ class DidJwtCredentialsVerifier implements JwtCredentialsVerifier {
         this.monitor = monitor;
     }
 
+    @Override
     public Result<Void> isSignedByIssuer(SignedJWT jwt) {
         String issuer;
         try {
@@ -61,6 +62,7 @@ class DidJwtCredentialsVerifier implements JwtCredentialsVerifier {
         return verifySignature(jwt, issuerPublicKey.getContent());
     }
 
+    @Override
     public Result<Void> verifyClaims(SignedJWT jwt, String expectedSubject) {
         JWTClaimsSet jwtClaimsSet;
         try {

--- a/extensions/identity-hub-verifier/src/main/java/org/eclipse/dataspaceconnector/identityhub/verifier/IdentityHubCredentialsVerifier.java
+++ b/extensions/identity-hub-verifier/src/main/java/org/eclipse/dataspaceconnector/identityhub/verifier/IdentityHubCredentialsVerifier.java
@@ -23,6 +23,7 @@ import org.eclipse.dataspaceconnector.identityhub.credentials.VerifiableCredenti
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.response.StatusResult;
 import org.eclipse.dataspaceconnector.spi.result.AbstractResult;
+import org.eclipse.dataspaceconnector.spi.result.Failure;
 import org.eclipse.dataspaceconnector.spi.result.Result;
 import org.jetbrains.annotations.NotNull;
 
@@ -107,7 +108,12 @@ public class IdentityHubCredentialsVerifier implements CredentialsVerifier {
 
         var claims = extractClaimsFromCredential(verifiedCredentials);
 
-        return Result.success(claims);
+        if (claims.failed()) {
+            monitor.severe(() -> String.format("Credentials verification failed: %s", claims.getFailureDetail()));
+            return Result.failure(claims.getFailureDetail());
+        } else {
+            return Result.success(claims.getContent());
+        }
     }
 
     @NotNull
@@ -127,21 +133,20 @@ public class IdentityHubCredentialsVerifier implements CredentialsVerifier {
     }
 
     @NotNull
-    private Map<String, Object> extractClaimsFromCredential(List<SignedJWT> verifiedCredentials) {
+    private VerificationResult extractClaimsFromCredential(List<SignedJWT> verifiedCredentials) {
         var result = verifiedCredentials.stream()
                 .map(verifiableCredentialsJwtService::extractCredential)
                 .collect(partitioningBy(AbstractResult::succeeded));
 
-        var successfulResults = result.get(true);
-        var failedResults = result.get(false);
-
-        if (!failedResults.isEmpty()) {
-            failedResults.forEach(f -> monitor.warning("Invalid credentials: " + f.getFailureDetail()));
-        }
-
-        return successfulResults.stream()
+        var successfulResults = result.get(true).stream()
                 .map(AbstractResult::getContent)
                 .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+        var failedResults = result.get(false).stream()
+                .map(AbstractResult::getFailureDetail)
+                .collect(Collectors.toList());
+
+        return new VerificationResult(successfulResults, failedResults);
     }
 
     private String getIdentityHubBaseUrl(DidDocument didDocument) {
@@ -152,5 +157,11 @@ public class IdentityHubCredentialsVerifier implements CredentialsVerifier {
                 .findFirst()
                 .map(Service::getServiceEndpoint)
                 .orElse(null);
+    }
+
+    private static class VerificationResult extends AbstractResult<Map<String, Object>, Failure> {
+        VerificationResult(Map<String, Object> succeededCredentials, List<String> failureMessage) {
+            super(succeededCredentials, failureMessage.isEmpty() ? null : new Failure(failureMessage));
+        }
     }
 }

--- a/extensions/identity-hub-verifier/src/main/java/org/eclipse/dataspaceconnector/identityhub/verifier/IdentityHubCredentialsVerifier.java
+++ b/extensions/identity-hub-verifier/src/main/java/org/eclipse/dataspaceconnector/identityhub/verifier/IdentityHubCredentialsVerifier.java
@@ -108,7 +108,9 @@ public class IdentityHubCredentialsVerifier implements CredentialsVerifier {
 
         var claims = extractClaimsFromCredential(verifiedCredentials.getContent());
 
-        var failureMessages = mergeFailureMessages(verifiedCredentials.getFailureMessages(), claims.getFailureMessages());
+        var failureMessages = Stream
+                .concat(verifiedCredentials.getFailureMessages().stream(), claims.getFailureMessages().stream())
+                .collect(Collectors.toList());
 
         var result = new AggregatedResult<>(claims.getContent(), failureMessages);
 
@@ -120,11 +122,6 @@ public class IdentityHubCredentialsVerifier implements CredentialsVerifier {
         } else {
             return Result.success(result.getContent());
         }
-    }
-
-    @NotNull
-    private List<String> mergeFailureMessages(Collection<String> messages, Collection<String> otherMessages) {
-        return Stream.concat(messages.stream(), otherMessages.stream()).collect(Collectors.toList());
     }
 
     @NotNull

--- a/extensions/identity-hub-verifier/src/main/java/org/eclipse/dataspaceconnector/identityhub/verifier/JwtCredentialsVerifier.java
+++ b/extensions/identity-hub-verifier/src/main/java/org/eclipse/dataspaceconnector/identityhub/verifier/JwtCredentialsVerifier.java
@@ -15,6 +15,7 @@
 package org.eclipse.dataspaceconnector.identityhub.verifier;
 
 import com.nimbusds.jwt.SignedJWT;
+import org.eclipse.dataspaceconnector.spi.result.Result;
 
 /**
  * Verifies verifiable credentials in JWT format.
@@ -27,7 +28,7 @@ public interface JwtCredentialsVerifier {
      * @param jwt to be verified.
      * @return if the JWT is signed by the claimed issuer.
      */
-    boolean isSignedByIssuer(SignedJWT jwt);
+    Result<Void> isSignedByIssuer(SignedJWT jwt);
 
     /**
      * Verifies if a JWT targets the given subject, and checks for the presence of the issuer ("iss") claim. The expiration ("exp") and not-before ("nbf") claims are verified if present as well.
@@ -36,5 +37,5 @@ public interface JwtCredentialsVerifier {
      * @param expectedSubject subject claim to verify.
      * @return if the JWT is valid and for the given subject
      */
-    boolean verifyClaims(SignedJWT jwt, String expectedSubject);
+    Result<Void> verifyClaims(SignedJWT jwt, String expectedSubject);
 }

--- a/extensions/identity-hub-verifier/src/test/java/org/eclipse/dataspaceconnector/identityhub/verifier/IdentityHubCredentialsVerifierTest.java
+++ b/extensions/identity-hub-verifier/src/test/java/org/eclipse/dataspaceconnector/identityhub/verifier/IdentityHubCredentialsVerifierTest.java
@@ -28,6 +28,7 @@ import org.eclipse.dataspaceconnector.identityhub.credentials.VerifiableCredenti
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.response.ResponseStatus;
 import org.eclipse.dataspaceconnector.spi.response.StatusResult;
+import org.eclipse.dataspaceconnector.spi.result.Result;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
 
@@ -82,8 +83,8 @@ public class IdentityHubCredentialsVerifierTest {
 
     private void setUpMocks(SignedJWT jws, boolean isSigned, boolean claimsValid) {
         when(identityHubClientMock.getVerifiableCredentials(HUB_BASE_URL)).thenReturn(StatusResult.success(List.of(jws)));
-        when(jwtCredentialsVerifierMock.isSignedByIssuer(jws)).thenReturn(isSigned);
-        when(jwtCredentialsVerifierMock.verifyClaims(eq(jws), any())).thenReturn(claimsValid);
+        when(jwtCredentialsVerifierMock.isSignedByIssuer(jws)).thenReturn(isSigned ? Result.success() : Result.failure("JWT not signed"));
+        when(jwtCredentialsVerifierMock.verifyClaims(eq(jws), any())).thenReturn(claimsValid ? Result.success() : Result.failure("VC not valid"));
     }
 
     @Test
@@ -98,8 +99,7 @@ public class IdentityHubCredentialsVerifierTest {
         var credentials = credentialsVerifier.getVerifiedCredentials(DID_DOCUMENT);
 
         // Assert
-        assertThat(credentials.succeeded()).isTrue();
-        assertThat(credentials.getContent().size()).isEqualTo(0);
+        assertThat(credentials.failed()).isTrue();
     }
 
     @Test

--- a/extensions/identity-hub-verifier/src/test/java/org/eclipse/dataspaceconnector/identityhub/verifier/IdentityHubCredentialsVerifierTest.java
+++ b/extensions/identity-hub-verifier/src/test/java/org/eclipse/dataspaceconnector/identityhub/verifier/IdentityHubCredentialsVerifierTest.java
@@ -29,9 +29,11 @@ import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.eclipse.dataspaceconnector.spi.response.ResponseStatus;
 import org.eclipse.dataspaceconnector.spi.response.StatusResult;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentMatchers;
 
 import java.util.List;
 import java.util.Map;
+import java.util.function.Supplier;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.dataspaceconnector.identityhub.junit.testfixtures.VerifiableCredentialTestUtil.buildSignedJwt;
@@ -39,7 +41,6 @@ import static org.eclipse.dataspaceconnector.identityhub.junit.testfixtures.Veri
 import static org.eclipse.dataspaceconnector.identityhub.junit.testfixtures.VerifiableCredentialTestUtil.generateVerifiableCredential;
 import static org.eclipse.dataspaceconnector.identityhub.junit.testfixtures.VerifiableCredentialTestUtil.toMap;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -62,7 +63,7 @@ public class IdentityHubCredentialsVerifierTest {
     private CredentialsVerifier credentialsVerifier = new IdentityHubCredentialsVerifier(identityHubClientMock, monitorMock, jwtCredentialsVerifierMock, verifiableCredentialsJwtService);
 
     @Test
-    public void getVerifiedClaims_getValidClaims() throws Exception {
+    public void getVerifiedClaims_getValidClaims() {
 
         // Arrange
         var credential = generateVerifiableCredential();
@@ -86,7 +87,7 @@ public class IdentityHubCredentialsVerifierTest {
     }
 
     @Test
-    public void getVerifiedClaims_filtersSignedByWrongIssuer() throws Exception {
+    public void getVerifiedClaims_filtersSignedByWrongIssuer() {
 
         // Arrange
         var credential = generateVerifiableCredential();
@@ -138,10 +139,8 @@ public class IdentityHubCredentialsVerifierTest {
         var credentials = credentialsVerifier.getVerifiedCredentials(DID_DOCUMENT);
 
         // Assert
-        assertThat(credentials.succeeded()).isTrue();
-        assertThat(credentials.getContent().isEmpty());
-        verify(monitorMock, times(1)).warning(anyString());
-
+        assertThat(credentials.failed()).isTrue();
+        verify(monitorMock, times(1)).severe(ArgumentMatchers.<Supplier<String>>any());
     }
 
     @Test
@@ -161,9 +160,8 @@ public class IdentityHubCredentialsVerifierTest {
         var credentials = credentialsVerifier.getVerifiedCredentials(DID_DOCUMENT);
 
         // Assert
-        assertThat(credentials.succeeded()).isTrue();
-        assertThat(credentials.getContent().isEmpty());
-        verify(monitorMock, times(1)).warning(anyString());
+        assertThat(credentials.failed()).isTrue();
+        verify(monitorMock, times(1)).severe(ArgumentMatchers.<Supplier<String>>any());
     }
 
 }


### PR DESCRIPTION
## What this PR changes/adds

IdentityHubCredentialsVerifier fails if the signature verification of at least one VerifiableCredential fail.

## Why it does that

We decided to always fail if something goes wrong with verifiable credentials, to notice potential problems easily.
In MVD, the VerfiableCredentials should always be valid.

Next steps: Adapt registry service to the new contract of the JwtCredentialsVerifier.

## Further notes

Added a test to increase the DidJwtCredentialsVerifier test coverage to 100%

Added a VerificationResult class to contain result + errors.
The long term goal is that the IdentityHubCredentialsVerifier returns an object that contains the successful result + failures, to let the client decide how to proceed with errors.

## Linked Issue(s)

https://github.com/agera-edc/IdentityHub/issues/47

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/identityservice/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/identityservice/blob/main/styleguide.md) for details_)
