### PR TITLE
Upload test coverage to codecov.

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -45,12 +45,16 @@ jobs:
         timeout-minutes: 10
         env:
           INTEGRATION_TEST: true
+          JACOCO: "true"
 
       - name: 'Publish Test Results'
         uses: EnricoMi/publish-unit-test-result-action@v1
         if: always()
         with:
           files: "**/test-results/**/*.xml"
+
+      - name: CodeCov
+        uses: codecov/codecov-action@v3
 
       - name: 'docker-compose logs'
         run: docker-compose -f system-tests/tests/docker-compose.yml logs

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,6 +19,7 @@ plugins {
     `maven-publish`
     id("org.gradle.crypto.checksum") version "1.4.0"
     id("io.github.gradle-nexus.publish-plugin") version "1.1.0"
+    jacoco
 }
 
 repositories {
@@ -84,6 +85,8 @@ subprojects{
 allprojects {
     apply(plugin = "maven-publish")
 
+    apply(plugin = "java")
+
     version = projectVersion
     group = projectGroup
 
@@ -147,10 +150,23 @@ allprojects {
         }
     }
 
-    tasks.withType<Test> {
+    tasks.test {
         useJUnitPlatform()
         testLogging {
             showStandardStreams = true
+        }
+    }
+
+    if (System.getenv("JACOCO") == "true") {
+        apply(plugin = "jacoco")
+        tasks.test {
+            finalizedBy(tasks.jacocoTestReport)
+        }
+        tasks.jacocoTestReport {
+            reports {
+                // Generate XML report for codecov.io
+                xml.required.set(true)
+            }
         }
     }
 


### PR DESCRIPTION
## What this PR changes/adds

Upload IdentityHub test coverage to codecov.
Report can be seen here: https://codecov.io/gh/agera-edc/IdentityHub/tree/feature%2F250%2F250-codecov
## Why it does that

To have codecov report to see the test coverage in PRs.

## Linked Issue(s)

https://github.com/agera-edc/MinimumViableDataspace/issues/250

## Checklist

- [x] added appropriate tests?
- [x] performed checkstyle check locally?
- [x] added/updated copyright headers?
- [x] documented public classes/methods?
- [x] added/updated relevant documentation?
- [x] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/identityservice/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/identityservice/blob/main/styleguide.md) for details_)
