### PR TITLE
chore: remove java faker

### DIFF
--- a/client-cli/build.gradle.kts
+++ b/client-cli/build.gradle.kts
@@ -11,7 +11,6 @@ val jacksonVersion: String by project
 val jupiterVersion: String by project
 val assertj: String by project
 val mockitoVersion: String by project
-val faker: String by project
 val okHttpVersion: String by project
 val nimbusVersion: String by project
 val bouncycastleVersion: String by project
@@ -29,7 +28,6 @@ dependencies {
     implementation("org.bouncycastle:bcpkix-jdk15on:${bouncycastleVersion}")
     testImplementation("org.assertj:assertj-core:${assertj}")
     testImplementation("org.mockito:mockito-core:${mockitoVersion}")
-    testImplementation("com.github.javafaker:javafaker:${faker}")
     testImplementation("org.junit.jupiter:junit-jupiter-api:${jupiterVersion}")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:${jupiterVersion}")
 }

--- a/client-cli/src/test/java/org/eclipse/dataspaceconnector/identityhub/cli/CliTestUtils.java
+++ b/client-cli/src/test/java/org/eclipse/dataspaceconnector/identityhub/cli/CliTestUtils.java
@@ -15,7 +15,6 @@
 package org.eclipse.dataspaceconnector.identityhub.cli;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.github.javafaker.Faker;
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jwt.SignedJWT;
 import org.eclipse.dataspaceconnector.iam.did.spi.key.PrivateKeyWrapper;
@@ -26,6 +25,7 @@ import org.eclipse.dataspaceconnector.identityhub.credentials.model.VerifiableCr
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 
 import java.util.Map;
+import java.util.UUID;
 
 import static org.eclipse.dataspaceconnector.identityhub.credentials.CryptoUtils.readPrivateEcKey;
 import static org.eclipse.dataspaceconnector.identityhub.credentials.CryptoUtils.readPublicEcKey;
@@ -36,7 +36,6 @@ class CliTestUtils {
     public static final String PRIVATE_KEY_PATH = "src/test/resources/test-private-key.pem";
     public static final PublicKeyWrapper PUBLIC_KEY;
     public static final PrivateKeyWrapper PRIVATE_KEY;
-    private static final Faker FAKER = new Faker();
     private static final VerifiableCredentialsJwtService VC_JWT_SERVICE = new VerifiableCredentialsJwtServiceImpl(new ObjectMapper(), mock(Monitor.class));
 
     static {
@@ -53,10 +52,10 @@ class CliTestUtils {
 
     public static VerifiableCredential createVerifiableCredential() {
         return VerifiableCredential.Builder.newInstance()
-                .id(FAKER.internet().uuid())
+                .id(UUID.randomUUID().toString())
                 .credentialSubject(Map.of(
-                        FAKER.internet().uuid(), FAKER.lorem().word(),
-                        FAKER.internet().uuid(), FAKER.lorem().word()))
+                        UUID.randomUUID().toString(), "value1",
+                        UUID.randomUUID().toString(), "value2"))
                 .build();
     }
 

--- a/client-cli/src/test/java/org/eclipse/dataspaceconnector/identityhub/cli/VerifiableCredentialsCommandTest.java
+++ b/client-cli/src/test/java/org/eclipse/dataspaceconnector/identityhub/cli/VerifiableCredentialsCommandTest.java
@@ -17,7 +17,6 @@ package org.eclipse.dataspaceconnector.identityhub.cli;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.github.javafaker.Faker;
 import com.nimbusds.jwt.SignedJWT;
 import org.eclipse.dataspaceconnector.identityhub.client.IdentityHubClient;
 import org.eclipse.dataspaceconnector.identityhub.credentials.VerifiableCredentialsJwtServiceImpl;
@@ -50,13 +49,12 @@ import static org.mockito.Mockito.when;
 
 class VerifiableCredentialsCommandTest {
 
-    private static final Faker FAKER = new Faker();
     private static final ObjectMapper MAPPER = new ObjectMapper();
     private static final VerifiableCredential VC1 = createVerifiableCredential();
     private static final SignedJWT SIGNED_VC1 = signVerifiableCredential(VC1);
     private static final VerifiableCredential VC2 = createVerifiableCredential();
     private static final SignedJWT SIGNED_VC2 = signVerifiableCredential(VC2);
-    private static final String HUB_URL = FAKER.internet().url();
+    private static final String HUB_URL = "http://some.test.url";
 
     private final IdentityHubCli app = new IdentityHubCli();
     private final CommandLine cmd = new CommandLine(app);
@@ -75,7 +73,7 @@ class VerifiableCredentialsCommandTest {
     @Test
     void getSelfDescription() throws JsonProcessingException {
         var selfDescription = MAPPER.createObjectNode();
-        selfDescription.put(FAKER.lorem().word(), FAKER.lorem().word());
+        selfDescription.put("key1", "value1");
         // arrange
         when(app.identityHubClient.getSelfDescription(app.hubUrl)).thenReturn(success(selfDescription));
 

--- a/extensions/identity-hub-verifier/build.gradle.kts
+++ b/extensions/identity-hub-verifier/build.gradle.kts
@@ -23,19 +23,18 @@ val nimbusVersion: String by project
 val okHttpVersion: String by project
 val mockitoVersion: String by project
 val assertj: String by project
-val faker: String by project
 
 dependencies {
     implementation(project(":extensions:identity-hub"))
     implementation(project(":identity-hub-core:identity-hub-client"))
     implementation(project(":spi:identity-hub-spi"))
-    implementation("${edcGroup}:core:${edcVersion}")
+    implementation("${edcGroup}:core-base:${edcVersion}")
+    implementation("${edcGroup}:core-boot:${edcVersion}")
     implementation("${edcGroup}:identity-did-spi:${edcVersion}")
     implementation("com.nimbusds:nimbus-jose-jwt:${nimbusVersion}")
     implementation("com.squareup.okhttp3:okhttp:${okHttpVersion}")
 
     testImplementation(testFixtures(project(":spi:identity-hub-spi")))
-    testImplementation("com.github.javafaker:javafaker:${faker}")
     testImplementation("org.assertj:assertj-core:${assertj}")
     testImplementation("org.mockito:mockito-core:${mockitoVersion}")
     testImplementation("${edcGroup}:identity-did-core:${edcVersion}")

--- a/extensions/identity-hub-verifier/src/test/java/org/eclipse/dataspaceconnector/identityhub/verifier/DidJwtCredentialsVerifierTest.java
+++ b/extensions/identity-hub-verifier/src/test/java/org/eclipse/dataspaceconnector/identityhub/verifier/DidJwtCredentialsVerifierTest.java
@@ -14,7 +14,6 @@
 
 package org.eclipse.dataspaceconnector.identityhub.verifier;
 
-import com.github.javafaker.Faker;
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.jwk.ECKey;
 import com.nimbusds.jwt.JWTClaimsSet;
@@ -44,12 +43,11 @@ import static org.mockito.Mockito.when;
 
 class DidJwtCredentialsVerifierTest {
 
-    private static final Faker FAKER = new Faker();
     private static final ECKey JWK = generateEcKey();
     private static final ECKey ANOTHER_JWK = generateEcKey();
-    private static final String ISSUER = FAKER.internet().url();
-    private static final String SUBJECT = FAKER.internet().url();
-    private static final String OTHER_SUBJECT = FAKER.internet().url() + "other";
+    private static final String ISSUER = "http://some.test.url";
+    private static final String SUBJECT = "http://some.test.url";
+    private static final String OTHER_SUBJECT = "http://some.test.url" + "other";
     private static final SignedJWT JWT = buildSignedJwt(generateVerifiableCredential(), ISSUER, SUBJECT, JWK);
     private DidPublicKeyResolver didPublicKeyResolver;
     private DidJwtCredentialsVerifier didJwtCredentialsVerifier;
@@ -95,7 +93,7 @@ class DidJwtCredentialsVerifierTest {
     void isSignedByIssuer_issuerDidCantBeResolved() throws ParseException {
 
         // Arrange
-        when(didPublicKeyResolver.resolvePublicKey(JWT.getJWTClaimsSet().getIssuer())).thenReturn(Result.failure(FAKER.lorem().sentence()));
+        when(didPublicKeyResolver.resolvePublicKey(JWT.getJWTClaimsSet().getIssuer())).thenReturn(Result.failure("test failure"));
 
         // Assert
         assertThat(didJwtCredentialsVerifier.isSignedByIssuer(JWT).failed()).isTrue();
@@ -138,7 +136,7 @@ class DidJwtCredentialsVerifierTest {
     void verifyClaims_OnInvalidJwt() throws Exception {
         // Arrange
         var jwt = mock(SignedJWT.class);
-        var message = FAKER.lorem().sentence();
+        var message = "Test Message";
         when(jwt.getJWTClaimsSet()).thenThrow(new ParseException(message, 0));
 
         // Act

--- a/extensions/identity-hub/build.gradle.kts
+++ b/extensions/identity-hub/build.gradle.kts
@@ -22,7 +22,6 @@ val edcVersion: String by project
 val edcGroup: String by project
 val jupiterVersion: String by project
 val restAssured: String by project
-val faker: String by project
 val nimbusVersion: String by project
 val mockitoVersion: String by project
 
@@ -39,7 +38,6 @@ dependencies {
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:${jupiterVersion}")
     testImplementation("org.assertj:assertj-core:${assertj}")
     testImplementation("io.rest-assured:rest-assured:${restAssured}")
-    testImplementation("com.github.javafaker:javafaker:${faker}")
     testImplementation("org.mockito:mockito-core:${mockitoVersion}")
     testImplementation(testFixtures(project(":spi:identity-hub-spi")))
 }

--- a/extensions/identity-hub/src/test/java/org/eclipse/dataspaceconnector/identityhub/api/IdentityHubControllerTest.java
+++ b/extensions/identity-hub/src/test/java/org/eclipse/dataspaceconnector/identityhub/api/IdentityHubControllerTest.java
@@ -14,7 +14,6 @@
 
 package org.eclipse.dataspaceconnector.identityhub.api;
 
-import com.github.javafaker.Faker;
 import com.nimbusds.jwt.SignedJWT;
 import io.restassured.specification.RequestSpecification;
 import org.eclipse.dataspaceconnector.identityhub.model.Descriptor;
@@ -28,6 +27,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import java.util.Base64;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 import static io.restassured.RestAssured.given;
@@ -50,10 +50,9 @@ class IdentityHubControllerTest {
 
     private static final int PORT = getFreePort();
     private static final String API_URL = String.format("http://localhost:%s/api", PORT);
-    private static final Faker FAKER = new Faker();
-    private static final String NONCE = FAKER.lorem().characters(32);
-    private static final String TARGET = FAKER.internet().url();
-    private static final String REQUEST_ID = FAKER.internet().uuid();
+    private static final String NONCE = UUID.randomUUID().toString();
+    private static final String TARGET = "http://some.test.url";
+    private static final String REQUEST_ID = UUID.randomUUID().toString();
 
     private static final String BASE_PATH = "/identity-hub";
 
@@ -65,8 +64,8 @@ class IdentityHubControllerTest {
     @Test
     void writeAndQueryObject() {
         // Arrange
-        var issuer = FAKER.internet().url();
-        var subject = FAKER.internet().url();
+        var issuer = "http://some.test.url";
+        var subject = "http://some.test.url";
         var credential = generateVerifiableCredential();
         var jwt = buildSignedJwt(credential, issuer, subject, generateEcKey());
 

--- a/extensions/identity-hub/src/test/java/org/eclipse/dataspaceconnector/identityhub/processor/CollectionsWriteProcessorTest.java
+++ b/extensions/identity-hub/src/test/java/org/eclipse/dataspaceconnector/identityhub/processor/CollectionsWriteProcessorTest.java
@@ -14,7 +14,6 @@
 
 package org.eclipse.dataspaceconnector.identityhub.processor;
 
-import com.github.javafaker.Faker;
 import com.nimbusds.jose.JWSAlgorithm;
 import com.nimbusds.jose.JWSHeader;
 import com.nimbusds.jose.crypto.ECDSASigner;
@@ -39,8 +38,6 @@ import static org.eclipse.dataspaceconnector.identityhub.model.MessageResponseOb
 
 public class CollectionsWriteProcessorTest {
 
-    private static final Faker FAKER = new Faker();
-
     private IdentityHubStore identityHubStore;
     private CollectionsWriteProcessor writeProcessor;
 
@@ -53,8 +50,8 @@ public class CollectionsWriteProcessorTest {
     @Test
     void writeCredentials() throws Exception {
         // Arrange
-        var issuer = FAKER.internet().url();
-        var subject = FAKER.internet().url();
+        var issuer = "http://some.test.url";
+        var subject = "http://some.test.url";
         var verifiableCredential = generateVerifiableCredential();
         var data = buildSignedJwt(verifiableCredential, issuer, subject, generateEcKey()).serialize().getBytes(StandardCharsets.UTF_8);
 

--- a/extensions/identity-hub/src/test/java/org/eclipse/dataspaceconnector/identityhub/store/IdentityHubInMemoryStoreTest.java
+++ b/extensions/identity-hub/src/test/java/org/eclipse/dataspaceconnector/identityhub/store/IdentityHubInMemoryStoreTest.java
@@ -14,25 +14,25 @@
 
 package org.eclipse.dataspaceconnector.identityhub.store;
 
-import com.github.javafaker.Faker;
 import org.eclipse.dataspaceconnector.identityhub.credentials.model.VerifiableCredential;
 import org.junit.jupiter.api.Test;
 
+import java.util.Random;
+import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class IdentityHubInMemoryStoreTest {
-    private static final Faker FAKER = new Faker();
 
     @Test
     void addAndReadVerifiableCredential() {
         // Arrange
         var store = new IdentityHubInMemoryStore();
-        var credentialsCount = FAKER.number().numberBetween(1, 10);
+        var credentialsCount = new Random().nextInt(10);
         var credentials = IntStream.range(0, credentialsCount)
-                .mapToObj(i -> VerifiableCredential.Builder.newInstance().id(FAKER.internet().uuid()).build())
+                .mapToObj(i -> VerifiableCredential.Builder.newInstance().id(UUID.randomUUID().toString()).build())
                 .collect(Collectors.toList());
 
         // Act

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ projectGroup=org.eclipse.dataspaceconnector.identityhub
 defaultVersion=0.0.1-SNAPSHOT
 
 edcGroup=org.eclipse.dataspaceconnector
-edcVersion=0.0.1-milestone-5.1
+edcVersion=0.0.1-milestone-6
 assertj=3.22.0
 jupiterVersion=5.8.2
 storageBlobVersion=12.11.0
@@ -13,7 +13,6 @@ rsApi=3.1.0
 swagger=2.1.13
 jacksonVersion=2.13.1
 restAssured=4.5.0
-faker=1.0.2
 okHttpVersion=4.9.3
 jetBrainsAnnotationsVersion=15.0
 nimbusVersion=8.22.1

--- a/identity-hub-core/identity-hub-client/build.gradle.kts
+++ b/identity-hub-core/identity-hub-client/build.gradle.kts
@@ -22,7 +22,6 @@ val okHttpVersion: String by project
 val edcVersion: String by project
 val edcGroup: String by project
 val jupiterVersion: String by project
-val faker: String by project
 val assertj: String by project
 val nimbusVersion: String by project
 val mockitoVersion: String by project
@@ -44,7 +43,6 @@ dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter-api:${jupiterVersion}")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:${jupiterVersion}")
     testImplementation("org.assertj:assertj-core:${assertj}")
-    testImplementation("com.github.javafaker:javafaker:${faker}")
     testImplementation("org.mockito:mockito-core:${mockitoVersion}")
 }
 

--- a/identity-hub-core/identity-hub-client/src/test/java/org/eclipse/dataspaceconnector/identityhub/client/IdentityHubClientImplIntegrationTest.java
+++ b/identity-hub-core/identity-hub-client/src/test/java/org/eclipse/dataspaceconnector/identityhub/client/IdentityHubClientImplIntegrationTest.java
@@ -15,7 +15,6 @@
 package org.eclipse.dataspaceconnector.identityhub.client;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.github.javafaker.Faker;
 import com.nimbusds.jwt.SignedJWT;
 import org.eclipse.dataspaceconnector.identityhub.credentials.model.VerifiableCredential;
 import org.eclipse.dataspaceconnector.junit.extensions.EdcExtension;
@@ -24,6 +23,8 @@ import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.dataspaceconnector.identityhub.junit.testfixtures.VerifiableCredentialTestUtil.buildSignedJwt;
@@ -34,8 +35,7 @@ import static org.mockito.Mockito.mock;
 class IdentityHubClientImplIntegrationTest {
 
     private static final String API_URL = "http://localhost:8181/api/identity-hub";
-    private static final Faker FAKER = new Faker();
-    private static final VerifiableCredential VERIFIABLE_CREDENTIAL = VerifiableCredential.Builder.newInstance().id(FAKER.internet().uuid()).build();
+    private static final VerifiableCredential VERIFIABLE_CREDENTIAL = VerifiableCredential.Builder.newInstance().id(UUID.randomUUID().toString()).build();
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
     private IdentityHubClient client;
 
@@ -55,7 +55,7 @@ class IdentityHubClientImplIntegrationTest {
 
     @Test
     void addAndQueryVerifiableCredentials() {
-        var jws = buildSignedJwt(VERIFIABLE_CREDENTIAL, FAKER.internet().url(), FAKER.internet().url(), generateEcKey());
+        var jws = buildSignedJwt(VERIFIABLE_CREDENTIAL, "http://test.url", "http://some.test.url", generateEcKey());
 
         addVerifiableCredential(jws);
         getVerifiableCredential(jws);

--- a/identity-hub-core/identity-hub-client/src/test/java/org/eclipse/dataspaceconnector/identityhub/client/IdentityHubClientImplTest.java
+++ b/identity-hub-core/identity-hub-client/src/test/java/org/eclipse/dataspaceconnector/identityhub/client/IdentityHubClientImplTest.java
@@ -15,7 +15,6 @@
 package org.eclipse.dataspaceconnector.identityhub.client;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.github.javafaker.Faker;
 import okhttp3.Interceptor;
 import okhttp3.MediaType;
 import okhttp3.OkHttpClient;
@@ -35,6 +34,7 @@ import org.junit.jupiter.api.Test;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.eclipse.dataspaceconnector.identityhub.junit.testfixtures.VerifiableCredentialTestUtil.buildSignedJwt;
@@ -43,15 +43,14 @@ import static org.eclipse.dataspaceconnector.identityhub.model.MessageResponseOb
 import static org.mockito.Mockito.mock;
 
 class IdentityHubClientImplTest {
-    private static final Faker FAKER = new Faker();
-    private static final String HUB_URL = String.format("https://%s", FAKER.internet().url());
-    private static final String VERIFIABLE_CREDENTIAL_ID = FAKER.internet().uuid();
+    private static final String HUB_URL = String.format("https://%s", "http://some.test.url");
+    private static final String VERIFIABLE_CREDENTIAL_ID = UUID.randomUUID().toString();
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
     @Test
     void getSelfDescription() {
         var selfDescription = OBJECT_MAPPER.createObjectNode();
-        selfDescription.put(FAKER.lorem().word(), FAKER.lorem().word());
+        selfDescription.put("key1", "value1");
 
         Interceptor interceptor = chain -> {
             var request = chain.request();
@@ -73,7 +72,7 @@ class IdentityHubClientImplTest {
     @Test
     void getSelfDescriptionServerError() {
 
-        var errorMessage = FAKER.lorem().sentence();
+        var errorMessage = "test-error-message";
         var body = "{}";
         var code = 500;
 
@@ -98,14 +97,14 @@ class IdentityHubClientImplTest {
     @Test
     void getVerifiableCredentials() {
         var credential = VerifiableCredential.Builder.newInstance().id(VERIFIABLE_CREDENTIAL_ID).build();
-        var jws = buildSignedJwt(credential, FAKER.internet().url(), FAKER.internet().url(), generateEcKey());
+        var jws = buildSignedJwt(credential, "http://some.test.url", "http://some.test.url", generateEcKey());
 
         Interceptor interceptor = chain -> {
             var request = chain.request();
             var replies = MessageResponseObject.Builder.newInstance().messageId(MESSAGE_ID_VALUE)
                     .status(MessageStatus.OK).entries(List.of(jws.serialize().getBytes(StandardCharsets.UTF_8))).build();
             var responseObject = ResponseObject.Builder.newInstance()
-                    .requestId(FAKER.internet().uuid())
+                    .requestId(UUID.randomUUID().toString())
                     .status(RequestStatus.OK)
                     .replies(List.of(replies))
                     .build();
@@ -129,7 +128,7 @@ class IdentityHubClientImplTest {
     @Test
     void getVerifiableCredentialsServerError() {
 
-        var errorMessage = FAKER.lorem().sentence();
+        var errorMessage = "test-message";
         var body = "{}";
         var code = 500;
 
@@ -174,8 +173,8 @@ class IdentityHubClientImplTest {
     @Test
     void addVerifiableCredentialsServerError() {
         var credential = VerifiableCredential.Builder.newInstance().id(VERIFIABLE_CREDENTIAL_ID).build();
-        var jws = buildSignedJwt(credential, FAKER.internet().url(), FAKER.internet().url(), generateEcKey());
-        var errorMessage = FAKER.lorem().sentence();
+        var jws = buildSignedJwt(credential, "http://some.test.url", "http://some.test.url", generateEcKey());
+        var errorMessage = "test error message";
         var body = "{}";
         int code = 500;
 
@@ -200,8 +199,8 @@ class IdentityHubClientImplTest {
     @Test
     void addVerifiableCredentialsIoException() {
         var credential = VerifiableCredential.Builder.newInstance().id(VERIFIABLE_CREDENTIAL_ID).build();
-        var jws = buildSignedJwt(credential, FAKER.internet().url(), FAKER.internet().url(), generateEcKey());
-        var exceptionMessage = FAKER.lorem().sentence();
+        var jws = buildSignedJwt(credential, "http://some.test.url", "http://some.test.url", generateEcKey());
+        var exceptionMessage = "test exception message";
         Interceptor interceptor = chain -> {
             throw new IOException(exceptionMessage);
         };

--- a/spi/identity-hub-spi/build.gradle.kts
+++ b/spi/identity-hub-spi/build.gradle.kts
@@ -21,7 +21,6 @@ plugins {
 val jetBrainsAnnotationsVersion: String by project
 val jacksonVersion: String by project
 val nimbusVersion: String by project
-val faker: String by project
 val edcGroup: String by project
 val edcVersion: String by project
 val jupiterVersion: String by project
@@ -36,14 +35,12 @@ dependencies {
     implementation("${edcGroup}:identity-did-crypto:${edcVersion}")
 
     testFixturesImplementation("com.nimbusds:nimbus-jose-jwt:${nimbusVersion}")
-    testFixturesImplementation("com.github.javafaker:javafaker:${faker}")
     testFixturesImplementation("${edcGroup}:identity-did-spi:${edcVersion}")
     testFixturesImplementation("${edcGroup}:identity-did-crypto:${edcVersion}")
     testImplementation("org.junit.jupiter:junit-jupiter-api:${jupiterVersion}")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:${jupiterVersion}")
     testImplementation("org.mockito:mockito-core:${mockitoVersion}")
     testImplementation("org.assertj:assertj-core:${assertj}")
-    testImplementation("com.github.javafaker:javafaker:${faker}")
 }
 
 publishing {

--- a/spi/identity-hub-spi/src/test/java/org/eclipse/dataspaceconnector/identityhub/credentials/VerifiableCredentialsJwtServiceTest.java
+++ b/spi/identity-hub-spi/src/test/java/org/eclipse/dataspaceconnector/identityhub/credentials/VerifiableCredentialsJwtServiceTest.java
@@ -15,7 +15,6 @@
 package org.eclipse.dataspaceconnector.identityhub.credentials;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.github.javafaker.Faker;
 import com.nimbusds.jose.JWSAlgorithm;
 import com.nimbusds.jose.JWSHeader;
 import com.nimbusds.jwt.JWTClaimsSet;
@@ -39,7 +38,6 @@ import static org.mockito.Mockito.mock;
 
 public class VerifiableCredentialsJwtServiceTest {
 
-    private static final Faker FAKER = new Faker();
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
     private static final VerifiableCredential VERIFIABLE_CREDENTIAL = generateVerifiableCredential();
     private static final JWSHeader JWS_HEADER = new JWSHeader.Builder(JWSAlgorithm.ES256).build();
@@ -58,8 +56,8 @@ public class VerifiableCredentialsJwtServiceTest {
     @Test
     public void buildSignedJwt_success() throws Exception {
         // Arrange
-        var issuer = FAKER.lorem().word();
-        var subject = FAKER.lorem().word();
+        var issuer = "test-issuer";
+        var subject = "test-subject";
         var startTime = Instant.now().truncatedTo(SECONDS);
 
         // Act
@@ -84,8 +82,8 @@ public class VerifiableCredentialsJwtServiceTest {
     @Test
     public void extractCredential_OnJwtWithValidCredential() throws Exception {
         // Arrange
-        var issuer = FAKER.lorem().word();
-        var subject = FAKER.lorem().word();
+        var issuer = "test-issuer";
+        var subject = "test-subject";
         var jwt = service.buildSignedJwt(VERIFIABLE_CREDENTIAL, issuer, subject, privateKey);
 
         // Act
@@ -109,7 +107,7 @@ public class VerifiableCredentialsJwtServiceTest {
     @Test
     public void extractCredential_OnJwtWithMissingVcField() {
         // Arrange
-        var claims = new JWTClaimsSet.Builder().claim(FAKER.lorem().word(), FAKER.lorem().word()).build();
+        var claims = new JWTClaimsSet.Builder().claim("test-name", "test-value").build();
         var jws = new SignedJWT(JWS_HEADER, claims);
 
         // Act
@@ -123,7 +121,7 @@ public class VerifiableCredentialsJwtServiceTest {
     @Test
     public void extractCredential_OnJwtWithWrongFormat() {
         // Arrange
-        var claims = new JWTClaimsSet.Builder().claim(VERIFIABLE_CREDENTIALS_KEY, FAKER.lorem().word()).build();
+        var claims = new JWTClaimsSet.Builder().claim(VERIFIABLE_CREDENTIALS_KEY, "test-value").build();
         var jws = new SignedJWT(JWS_HEADER, claims);
 
         // Act

--- a/spi/identity-hub-spi/src/testFixtures/java/org/eclipse/dataspaceconnector/identityhub/junit/testfixtures/VerifiableCredentialTestUtil.java
+++ b/spi/identity-hub-spi/src/testFixtures/java/org/eclipse/dataspaceconnector/identityhub/junit/testfixtures/VerifiableCredentialTestUtil.java
@@ -14,7 +14,6 @@
 
 package org.eclipse.dataspaceconnector.identityhub.junit.testfixtures;
 
-import com.github.javafaker.Faker;
 import com.nimbusds.jose.JOSEException;
 import com.nimbusds.jose.JWSAlgorithm;
 import com.nimbusds.jose.JWSHeader;
@@ -30,20 +29,20 @@ import org.eclipse.dataspaceconnector.iam.did.spi.key.PublicKeyWrapper;
 import org.eclipse.dataspaceconnector.identityhub.credentials.model.VerifiableCredential;
 
 import java.util.Map;
+import java.util.UUID;
 
 /**
  * Util class to manipulate VerifiableCredentials in tests.
  */
 public class VerifiableCredentialTestUtil {
-    private static final Faker FAKER = new Faker();
     private static final ECKeyGenerator EC_KEY_GENERATOR = new ECKeyGenerator(Curve.P_256);
 
     public static VerifiableCredential generateVerifiableCredential() {
         return VerifiableCredential.Builder.newInstance()
-                .id(FAKER.internet().uuid())
+                .id(UUID.randomUUID().toString())
                 .credentialSubject(Map.of(
-                        FAKER.internet().uuid(), FAKER.lorem().word(),
-                        FAKER.internet().uuid(), FAKER.lorem().word()))
+                        UUID.randomUUID().toString(), "cred1",
+                        UUID.randomUUID().toString(), "cred2"))
                 .build();
     }
 

--- a/system-tests/launcher/build.gradle.kts
+++ b/system-tests/launcher/build.gradle.kts
@@ -24,7 +24,8 @@ val identityHubVersion: String by project
 val identityHubGroup: String by project
 
 dependencies {
-    implementation("${edcGroup}:core:${edcVersion}")
+    implementation("${edcGroup}:core-base:${edcVersion}")
+    implementation("${edcGroup}:core-boot:${edcVersion}")
     implementation(project(":extensions:identity-hub"))
 }
 

--- a/system-tests/tests/build.gradle.kts
+++ b/system-tests/tests/build.gradle.kts
@@ -22,7 +22,6 @@ val jacksonVersion: String by project
 val jupiterVersion: String by project
 val assertj: String by project
 val mockitoVersion: String by project
-val faker: String by project
 val okHttpVersion: String by project
 val nimbusVersion: String by project
 val bouncycastleVersion: String by project
@@ -44,7 +43,6 @@ dependencies {
     testImplementation("org.bouncycastle:bcpkix-jdk15on:${bouncycastleVersion}")
     testImplementation("org.assertj:assertj-core:${assertj}")
     testImplementation("org.mockito:mockito-core:${mockitoVersion}")
-    testImplementation("com.github.javafaker:javafaker:${faker}")
     testImplementation("org.junit.jupiter:junit-jupiter-api:${jupiterVersion}")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:${jupiterVersion}")
 }

--- a/system-tests/tests/src/test/java/org/eclipse/dataspaceconnector/identityhub/systemtests/VerifiableCredentialsIntegrationTest.java
+++ b/system-tests/tests/src/test/java/org/eclipse/dataspaceconnector/identityhub/systemtests/VerifiableCredentialsIntegrationTest.java
@@ -16,7 +16,6 @@ package org.eclipse.dataspaceconnector.identityhub.systemtests;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.github.javafaker.Faker;
 import net.minidev.json.JSONObject;
 import org.eclipse.dataspaceconnector.iam.did.spi.credentials.CredentialsVerifier;
 import org.eclipse.dataspaceconnector.iam.did.spi.resolution.DidResolverRegistry;
@@ -31,6 +30,7 @@ import picocli.CommandLine;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.Map;
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.InstanceOfAssertFactories.map;
@@ -40,17 +40,16 @@ import static org.eclipse.dataspaceconnector.identityhub.credentials.VerifiableC
 @ExtendWith(EdcExtension.class)
 class VerifiableCredentialsIntegrationTest {
 
-    private static final Faker FAKER = new Faker();
     private static final String HUB_URL = "http://localhost:8182/api/identity-hub";
     private static final String AUTHORITY_DID = "did:web:localhost%3A8080:authority";
     private static final String PARTICIPANT_DID = "did:web:localhost%3A8080:participant";
     private static final String AUTHORITY_PRIVATE_KEY_PATH = "resources/jwt/authority/private-key.pem";
     private static final ObjectMapper MAPPER = new ObjectMapper();
     private static final VerifiableCredential VC1 = VerifiableCredential.Builder.newInstance()
-            .id(FAKER.internet().uuid())
+            .id(UUID.randomUUID().toString())
             .credentialSubject(Map.of(
-                    FAKER.internet().uuid(), FAKER.lorem().word(),
-                    FAKER.internet().uuid(), FAKER.lorem().word()))
+                    UUID.randomUUID().toString(), "value1",
+                    UUID.randomUUID().toString(), "value2"))
             .build();
 
     private final CommandLine cmd = IdentityHubCli.getCommandLine();


### PR DESCRIPTION
## What this PR changes/adds

completely removes the `javafaker` dependency from the project as it is not needed.

## Why it does that

cleanup. small dependency footprint.

## Further notes
.

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
