### PR TITLE
chore: bumped all versions

### DIFF
--- a/client-cli/build.gradle.kts
+++ b/client-cli/build.gradle.kts
@@ -31,6 +31,9 @@ dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter-api:${jupiterVersion}")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:${jupiterVersion}")
 }
+repositories {
+    mavenCentral()
+}
 
 application {
     mainClass.set("org.eclipse.dataspaceconnector.identityhub.cli.IdentityHubCli")

--- a/client-cli/src/test/java/org/eclipse/dataspaceconnector/identityhub/cli/VerifiableCredentialsCommandTest.java
+++ b/client-cli/src/test/java/org/eclipse/dataspaceconnector/identityhub/cli/VerifiableCredentialsCommandTest.java
@@ -138,8 +138,9 @@ class VerifiableCredentialsCommandTest {
         assertThat(verifyVerifiableCredentialSignature(signedJwt)).isTrue();
 
         // verify verifiable credential claim
-        var vcClaim = signedJwt.getJWTClaimsSet().getJSONObjectClaim(VERIFIABLE_CREDENTIALS_KEY).toJSONString();
-        var verifiableCredential = MAPPER.readValue(vcClaim, VerifiableCredential.class);
+        var vcClaim = signedJwt.getJWTClaimsSet().getJSONObjectClaim(VERIFIABLE_CREDENTIALS_KEY);
+        var vcClaimJson = MAPPER.writeValueAsString(vcClaim);
+        var verifiableCredential = MAPPER.readValue(vcClaimJson, VerifiableCredential.class);
         assertThat(verifiableCredential).usingRecursiveComparison().isEqualTo(VC1);
     }
 

--- a/extensions/identity-hub-verifier/src/main/java/org/eclipse/dataspaceconnector/identityhub/verifier/DidJwtCredentialsVerifier.java
+++ b/extensions/identity-hub-verifier/src/main/java/org/eclipse/dataspaceconnector/identityhub/verifier/DidJwtCredentialsVerifier.java
@@ -32,11 +32,10 @@ import java.util.Set;
  */
 class DidJwtCredentialsVerifier implements JwtCredentialsVerifier {
 
-    private final DidPublicKeyResolver didPublicKeyResolver;
-    private final Monitor monitor;
-
     // RFC 7519 Registered (standard) claim
     private static final String ISSUER_CLAIM = "iss";
+    private final DidPublicKeyResolver didPublicKeyResolver;
+    private final Monitor monitor;
 
     DidJwtCredentialsVerifier(DidPublicKeyResolver didPublicKeyResolver, Monitor monitor) {
         this.didPublicKeyResolver = didPublicKeyResolver;
@@ -82,7 +81,7 @@ class DidJwtCredentialsVerifier implements JwtCredentialsVerifier {
         var claimsVerifier = new DefaultJWTClaimsVerifier<>(exactMatchClaims, requiredClaims);
 
         try {
-            claimsVerifier.verify(jwtClaimsSet);
+            claimsVerifier.verify(jwtClaimsSet, null);
         } catch (BadJWTException e) {
             var failureMessage = "Failure verifying JWT token";
             monitor.warning(failureMessage, e);

--- a/extensions/identity-hub-verifier/src/test/java/org/eclipse/dataspaceconnector/identityhub/verifier/CredentialsVerifierExtensionTest.java
+++ b/extensions/identity-hub-verifier/src/test/java/org/eclipse/dataspaceconnector/identityhub/verifier/CredentialsVerifierExtensionTest.java
@@ -62,7 +62,7 @@ class CredentialsVerifierExtensionTest {
     private IdentityHubClient identityHubClient;
 
     private static DidDocument createDidDocument(ECKey jwk) throws JsonProcessingException {
-        var ecKey = OBJECT_MAPPER.readValue(jwk.toJSONObject().toJSONString(), EllipticCurvePublicKey.class);
+        var ecKey = OBJECT_MAPPER.readValue(jwk.toJSONString(), EllipticCurvePublicKey.class);
         return DidDocument.Builder.newInstance()
                 .id(SUBJECT)
                 .service(List.of(new Service("IdentityHub", "IdentityHub", API_URL)))

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,21 +1,20 @@
 projectGroup=org.eclipse.dataspaceconnector.identityhub
 # defaultVersion is used when "-PidentityHubVersion...." is no supplied. Should always be equal to edcVersion!
 defaultVersion=0.0.1-SNAPSHOT
-
 edcGroup=org.eclipse.dataspaceconnector
 edcVersion=0.0.1-milestone-6
-assertj=3.22.0
-jupiterVersion=5.8.2
+assertj=3.23.1
+jupiterVersion=5.9.0
 storageBlobVersion=12.11.0
-mockitoVersion=4.2.0
+mockitoVersion=4.8.0
 awaitility=4.1.1
 rsApi=3.1.0
 swagger=2.1.13
-jacksonVersion=2.13.1
+jacksonVersion=2.13.4
 restAssured=4.5.0
-okHttpVersion=4.9.3
+okHttpVersion=4.10.0
 jetBrainsAnnotationsVersion=15.0
-nimbusVersion=8.22.1
+nimbusVersion=9.24.4
 bouncycastleVersion=1.70
 picoCliVersion=4.6.3
 

--- a/system-tests/tests/src/test/java/org/eclipse/dataspaceconnector/identityhub/systemtests/VerifiableCredentialsIntegrationTest.java
+++ b/system-tests/tests/src/test/java/org/eclipse/dataspaceconnector/identityhub/systemtests/VerifiableCredentialsIntegrationTest.java
@@ -16,7 +16,6 @@ package org.eclipse.dataspaceconnector.identityhub.systemtests;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import net.minidev.json.JSONObject;
 import org.eclipse.dataspaceconnector.iam.did.spi.credentials.CredentialsVerifier;
 import org.eclipse.dataspaceconnector.iam.did.spi.resolution.DidResolverRegistry;
 import org.eclipse.dataspaceconnector.identityhub.cli.IdentityHubCli;
@@ -48,8 +47,8 @@ class VerifiableCredentialsIntegrationTest {
     private static final VerifiableCredential VC1 = VerifiableCredential.Builder.newInstance()
             .id(UUID.randomUUID().toString())
             .credentialSubject(Map.of(
-                    UUID.randomUUID().toString(), "value1",
-                    UUID.randomUUID().toString(), "value2"))
+                    "key1", "value1",
+                    "key2", "value2"))
             .build();
 
     private final CommandLine cmd = IdentityHubCli.getCommandLine();
@@ -95,7 +94,7 @@ class VerifiableCredentialsIntegrationTest {
         var vcs = verifiedCredentials.getContent();
         assertThat(vcs)
                 .extractingByKey(VC1.getId())
-                .asInstanceOf(map(String.class, JSONObject.class))
+                .asInstanceOf(map(String.class, Map.class))
                 .extractingByKey(VERIFIABLE_CREDENTIALS_KEY)
                 .satisfies(c -> {
                     assertThat(MAPPER.convertValue(c, VerifiableCredential.class))


### PR DESCRIPTION
## What this PR changes/adds

Bumps versions of all dependencies, including EDC, which was bumped to `milestone-6`.

## Why it does that

This is intended to pave the way for the first real release of IdentityHub to MavenCentral.

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
