### PR TITLE
build: add release workflow file

### DIFF
--- a/.github/workflows/release-identityhub.yml
+++ b/.github/workflows/release-identityhub.yml
@@ -1,0 +1,77 @@
+name: Create IdentityHub Release
+on:
+  workflow_dispatch:
+    inputs:
+      IDENTITYHUB_VERSION:
+        description: 'Version string that is used for publishing (e.g. "1.0.0", NOT "v1.0.0"). Appending -SNAPSHOT will create a snapshot release.'
+        required: true
+        type: string
+
+
+env:
+  IDENTITYHUB_VERSION: ${{ github.event.inputs.ih_version || inputs.ih_version }}
+
+jobs:
+  Prepare-Release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      # create tag on the current branch using GitHub's own API
+      - name: Create tag on current branch (main)
+        uses: actions/github-script@v6
+        with:
+          script: |
+            github.rest.git.createRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: 'refs/tags/v${{ env.IDENTITYHUB_VERSION }}',
+              sha: context.sha
+            })
+
+      # create merge commit main -> releases encoding the version in the commit message
+      - name: Merge main -> releases
+        uses: everlytic/branch-merge@1.1.4
+        with:
+          github_token: ${{ github.token }}
+          source_ref: ${{ github.ref }}
+          target_branch: 'releases'
+          commit_message_template: 'Merge commit for release of version v${{ env.IDENTITYHUB_VERSION }}'
+
+      # Trigger EF Jenkins. This job waits for Jenkins to complete the publishing, which may take a long time, because every
+      # module is signed individually, and parallelism is not available. Hence, the increased timeout of 3600 seconds.
+      # There is no way to cancel the process on Jenkins from withing GitHub.
+      - name: Trigger Release on EF Jenkins
+        uses: toptal/jenkins-job-trigger-action@master
+        with:
+          jenkins_url: "https://ci.eclipse.org/dataspaceconnector/"
+          jenkins_user: ${{ secrets.EF_JENKINS_USER }}
+          jenkins_token: ${{ secrets.EF_JENKINS_TOKEN }}
+          job_name: "IdentityHub-Autobuild-Release"
+          job_params: |
+            {
+              "VERSION": "${{ env.IDENTITYHUB_VERSION }}"
+            }
+          job_timeout: "3600" # Default 30 sec. (optional)
+    outputs:
+      ih-version: ${{ env.IDENTITYHUB_VERSION }}
+
+  Github-Release:
+    # cannot use the workflow-level env yet as it does not yet exist, must take output from previous job
+    if: ${{ !endsWith( needs.Prepare-Release.outputs.ih-version, '-SNAPSHOT') }}
+    needs:
+      - Prepare-Release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: main
+      - name: Create GitHub Release
+        uses: ncipollo/release-action@v1
+        with:
+          generateReleaseNotes: true
+          tag: "v${{ env.IDENTITYHUB_VERSION }}"
+          token: ${{ secrets.GITHUB_TOKEN }}
+          removeArtifacts: true


### PR DESCRIPTION
## What this PR changes/adds

Adds a workflow file to trigger the creation of a release on Jenkins using Github Actions.

## Why it does that

Convenient way to create a new release/snapshot from withing Github

## Further notes

.

## Linked Issue(s)

.

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
