### PR TITLE
fix: fixed input param for release workflow

### DIFF
--- a/.github/workflows/release-identityhub.yml
+++ b/.github/workflows/release-identityhub.yml
@@ -2,7 +2,7 @@ name: Create IdentityHub Release
 on:
   workflow_dispatch:
     inputs:
-      IDENTITYHUB_VERSION:
+      ih_version:
         description: 'Version string that is used for publishing (e.g. "1.0.0", NOT "v1.0.0"). Appending -SNAPSHOT will create a snapshot release.'
         required: true
         type: string


### PR DESCRIPTION
## What this PR changes/adds

changes the name of the input parameter for the release workflow. 

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
