### PR TITLE
chore: revert nimbus version to 8.23 (used by EDC)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -14,7 +14,7 @@ jacksonVersion=2.13.4
 restAssured=4.5.0
 okHttpVersion=4.10.0
 jetBrainsAnnotationsVersion=15.0
-nimbusVersion=9.24.4
+nimbusVersion=8.23
 bouncycastleVersion=1.70
 picoCliVersion=4.6.3
 


### PR DESCRIPTION
## What this PR changes/adds

Reverts the version of Nimbus JWT used by IdentityHub to 8.23.

## Why it does that

EDC still uses 8.23, so referencing a different version in IH would potentially (and actually) cause runtime problems, i.e. `NoSuchMethodError`s.

Note that this does not occur in IH directly, but in _it's_ downstream projects, e.g. `RegistrationService`.

## Further notes

_List other areas of code that have changed but are not necessarily linked to the main feature. This could be method
signature changes, package declarations, bugs that were encountered and were fixed inline, etc._

## Linked Issue(s)

Closes # <-- _insert Issue number if one exists_

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
