### PR TITLE
chore: adopt current EDC snapshot 

### DIFF
--- a/extensions/identity-hub-verifier/src/main/java/org/eclipse/dataspaceconnector/identityhub/verifier/CredentialsVerifierExtension.java
+++ b/extensions/identity-hub-verifier/src/main/java/org/eclipse/dataspaceconnector/identityhub/verifier/CredentialsVerifierExtension.java
@@ -18,9 +18,9 @@ import okhttp3.OkHttpClient;
 import org.eclipse.dataspaceconnector.iam.did.spi.credentials.CredentialsVerifier;
 import org.eclipse.dataspaceconnector.identityhub.client.IdentityHubClientImpl;
 import org.eclipse.dataspaceconnector.identityhub.credentials.VerifiableCredentialsJwtServiceImpl;
+import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Inject;
+import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Provider;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
-import org.eclipse.dataspaceconnector.spi.system.Inject;
-import org.eclipse.dataspaceconnector.spi.system.Provider;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtension;
 import org.eclipse.dataspaceconnector.spi.types.TypeManager;
 

--- a/extensions/identity-hub-verifier/src/main/java/org/eclipse/dataspaceconnector/identityhub/verifier/JwtCredentialsVerifierExtension.java
+++ b/extensions/identity-hub-verifier/src/main/java/org/eclipse/dataspaceconnector/identityhub/verifier/JwtCredentialsVerifierExtension.java
@@ -15,9 +15,9 @@
 package org.eclipse.dataspaceconnector.identityhub.verifier;
 
 import org.eclipse.dataspaceconnector.iam.did.spi.resolution.DidPublicKeyResolver;
+import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Inject;
+import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Provider;
 import org.eclipse.dataspaceconnector.spi.monitor.Monitor;
-import org.eclipse.dataspaceconnector.spi.system.Inject;
-import org.eclipse.dataspaceconnector.spi.system.Provider;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtension;
 
 /**

--- a/extensions/identity-hub/src/main/java/org/eclipse/dataspaceconnector/identityhub/IdentityHubExtension.java
+++ b/extensions/identity-hub/src/main/java/org/eclipse/dataspaceconnector/identityhub/IdentityHubExtension.java
@@ -22,10 +22,10 @@ import org.eclipse.dataspaceconnector.identityhub.processor.MessageProcessorRegi
 import org.eclipse.dataspaceconnector.identityhub.selfdescription.SelfDescriptionLoader;
 import org.eclipse.dataspaceconnector.identityhub.store.IdentityHubInMemoryStore;
 import org.eclipse.dataspaceconnector.identityhub.store.IdentityHubStore;
-import org.eclipse.dataspaceconnector.spi.EdcSetting;
+import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.EdcSetting;
+import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Inject;
+import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Provider;
 import org.eclipse.dataspaceconnector.spi.WebService;
-import org.eclipse.dataspaceconnector.spi.system.Inject;
-import org.eclipse.dataspaceconnector.spi.system.Provider;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtension;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ projectGroup=org.eclipse.dataspaceconnector.identityhub
 # defaultVersion is used when "-PidentityHubVersion...." is no supplied. Should always be equal to edcVersion!
 defaultVersion=0.0.1-SNAPSHOT
 edcGroup=org.eclipse.dataspaceconnector
-edcVersion=0.0.1-milestone-6
+edcVersion=0.0.1-20220930-SNAPSHOT
 assertj=3.23.1
 jupiterVersion=5.9.0
 storageBlobVersion=12.11.0

--- a/system-tests/tests/src/test/java/org/eclipse/dataspaceconnector/identityhub/systemtests/VerifiableCredentialsIntegrationTest.java
+++ b/system-tests/tests/src/test/java/org/eclipse/dataspaceconnector/identityhub/systemtests/VerifiableCredentialsIntegrationTest.java
@@ -35,7 +35,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.InstanceOfAssertFactories.map;
 import static org.eclipse.dataspaceconnector.identityhub.credentials.VerifiableCredentialsJwtService.VERIFIABLE_CREDENTIALS_KEY;
 
-//@IntegrationTest
+@IntegrationTest
 @ExtendWith(EdcExtension.class)
 class VerifiableCredentialsIntegrationTest {
 

--- a/system-tests/tests/src/test/java/org/eclipse/dataspaceconnector/identityhub/systemtests/VerifiableCredentialsIntegrationTest.java
+++ b/system-tests/tests/src/test/java/org/eclipse/dataspaceconnector/identityhub/systemtests/VerifiableCredentialsIntegrationTest.java
@@ -35,7 +35,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.InstanceOfAssertFactories.map;
 import static org.eclipse.dataspaceconnector.identityhub.credentials.VerifiableCredentialsJwtService.VERIFIABLE_CREDENTIALS_KEY;
 
-@IntegrationTest
+//@IntegrationTest
 @ExtendWith(EdcExtension.class)
 class VerifiableCredentialsIntegrationTest {
 


### PR DESCRIPTION
## What this PR changes/adds

The recent introduction of the `runtime-metamodel` library requires a few changes in IdentityHub as well, specifically package declarations.

## Why it does that

prepare for any upcoming EDC releases.

## Further notes

- from this point forward, `IdentityHub` will use EDC version `0.0.1-20220930-SNAPSHOT` version, which is the latest nightly at the time of this writing.


## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
