### PR TITLE
fix(IdentityHub): adds transactional access to IdentityHubStore

### DIFF
--- a/extensions/identity-hub/build.gradle.kts
+++ b/extensions/identity-hub/build.gradle.kts
@@ -31,6 +31,7 @@ dependencies {
     implementation(project(":spi:identity-hub-store-spi"))
     implementation("${edcGroup}:http:${edcVersion}")
     implementation("com.nimbusds:nimbus-jose-jwt:${nimbusVersion}")
+    implementation("${edcGroup}:transaction-spi:${edcVersion}")
 
     testImplementation("${edcGroup}:common-util:${edcVersion}:test-fixtures")
     testImplementation("${edcGroup}:junit:${edcVersion}")

--- a/extensions/identity-hub/src/main/java/org/eclipse/dataspaceconnector/identityhub/IdentityHubExtension.java
+++ b/extensions/identity-hub/src/main/java/org/eclipse/dataspaceconnector/identityhub/IdentityHubExtension.java
@@ -28,6 +28,7 @@ import org.eclipse.dataspaceconnector.runtime.metamodel.annotation.Provider;
 import org.eclipse.dataspaceconnector.spi.WebService;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtension;
 import org.eclipse.dataspaceconnector.spi.system.ServiceExtensionContext;
+import org.eclipse.dataspaceconnector.spi.transaction.TransactionContext;
 
 import java.util.Optional;
 
@@ -50,12 +51,16 @@ public class IdentityHubExtension implements ServiceExtension {
     @Inject
     private IdentityHubStore identityHubStore;
 
+    @Inject
+    private TransactionContext transactionContext;
+
+
     @Override
     public void initialize(ServiceExtensionContext context) {
 
         var methodProcessorFactory = new MessageProcessorRegistry();
-        methodProcessorFactory.register(COLLECTIONS_QUERY, new CollectionsQueryProcessor(identityHubStore));
-        methodProcessorFactory.register(COLLECTIONS_WRITE, new CollectionsWriteProcessor(identityHubStore));
+        methodProcessorFactory.register(COLLECTIONS_QUERY, new CollectionsQueryProcessor(identityHubStore, transactionContext));
+        methodProcessorFactory.register(COLLECTIONS_WRITE, new CollectionsWriteProcessor(identityHubStore, transactionContext));
         methodProcessorFactory.register(FEATURE_DETECTION_READ, new FeatureDetectionReadProcessor());
 
         var loader = new SelfDescriptionLoader(context.getTypeManager().getMapper());

--- a/extensions/identity-hub/src/main/java/org/eclipse/dataspaceconnector/identityhub/processor/CollectionsQueryProcessor.java
+++ b/extensions/identity-hub/src/main/java/org/eclipse/dataspaceconnector/identityhub/processor/CollectionsQueryProcessor.java
@@ -17,6 +17,7 @@ package org.eclipse.dataspaceconnector.identityhub.processor;
 import org.eclipse.dataspaceconnector.identityhub.model.MessageResponseObject;
 import org.eclipse.dataspaceconnector.identityhub.model.MessageStatus;
 import org.eclipse.dataspaceconnector.identityhub.store.IdentityHubStore;
+import org.eclipse.dataspaceconnector.spi.transaction.TransactionContext;
 
 import java.util.Collection;
 
@@ -29,13 +30,16 @@ public class CollectionsQueryProcessor implements MessageProcessor {
 
     private final IdentityHubStore identityHubStore;
 
-    public CollectionsQueryProcessor(IdentityHubStore identityHubStore) {
+    private final TransactionContext transactionContext;
+
+    public CollectionsQueryProcessor(IdentityHubStore identityHubStore, TransactionContext transactionContext) {
         this.identityHubStore = identityHubStore;
+        this.transactionContext = transactionContext;
     }
 
     @Override
     public MessageResponseObject process(byte[] data) {
-        Collection<?> entries = identityHubStore.getAll();
+        Collection<?> entries = transactionContext.execute(identityHubStore::getAll);
         return MessageResponseObject.Builder.newInstance()
                 .messageId(MESSAGE_ID_VALUE)
                 .status(MessageStatus.OK)

--- a/extensions/identity-hub/src/main/java/org/eclipse/dataspaceconnector/identityhub/processor/CollectionsWriteProcessor.java
+++ b/extensions/identity-hub/src/main/java/org/eclipse/dataspaceconnector/identityhub/processor/CollectionsWriteProcessor.java
@@ -18,6 +18,7 @@ import com.nimbusds.jwt.SignedJWT;
 import org.eclipse.dataspaceconnector.identityhub.model.MessageResponseObject;
 import org.eclipse.dataspaceconnector.identityhub.model.MessageStatus;
 import org.eclipse.dataspaceconnector.identityhub.store.IdentityHubStore;
+import org.eclipse.dataspaceconnector.spi.transaction.TransactionContext;
 
 import java.text.ParseException;
 
@@ -31,8 +32,11 @@ public class CollectionsWriteProcessor implements MessageProcessor {
     private static final String VERIFIABLE_CREDENTIALS_KEY = "vc";
     private final IdentityHubStore identityHubStore;
 
-    public CollectionsWriteProcessor(IdentityHubStore identityHubStore) {
+    private final TransactionContext transactionContext;
+
+    public CollectionsWriteProcessor(IdentityHubStore identityHubStore, TransactionContext transactionContext) {
         this.identityHubStore = identityHubStore;
+        this.transactionContext = transactionContext;
     }
 
     @Override
@@ -46,7 +50,7 @@ public class CollectionsWriteProcessor implements MessageProcessor {
             return MessageResponseObject.Builder.newInstance().messageId(MESSAGE_ID_VALUE).status(MessageStatus.MALFORMED_MESSAGE).build();
         }
 
-        identityHubStore.add(data);
+        transactionContext.execute(() -> identityHubStore.add(data));
         return MessageResponseObject.Builder.newInstance().messageId(MESSAGE_ID_VALUE).status(MessageStatus.OK).build();
     }
 }

--- a/extensions/identity-hub/src/test/java/org/eclipse/dataspaceconnector/identityhub/processor/CollectionsWriteProcessorTest.java
+++ b/extensions/identity-hub/src/test/java/org/eclipse/dataspaceconnector/identityhub/processor/CollectionsWriteProcessorTest.java
@@ -23,6 +23,7 @@ import org.eclipse.dataspaceconnector.identityhub.model.MessageResponseObject;
 import org.eclipse.dataspaceconnector.identityhub.model.MessageStatus;
 import org.eclipse.dataspaceconnector.identityhub.store.IdentityHubInMemoryStore;
 import org.eclipse.dataspaceconnector.identityhub.store.IdentityHubStore;
+import org.eclipse.dataspaceconnector.spi.transaction.NoopTransactionContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -44,7 +45,7 @@ public class CollectionsWriteProcessorTest {
     @BeforeEach
     void setUp() {
         identityHubStore = new IdentityHubInMemoryStore();
-        writeProcessor = new CollectionsWriteProcessor(identityHubStore);
+        writeProcessor = new CollectionsWriteProcessor(identityHubStore, new NoopTransactionContext());
     }
 
     @Test


### PR DESCRIPTION
## What this PR changes/adds

Adds transactional access to the `IdentityHubStore`

## Why it does that

As of now the transactional context was not created.

## Linked Issue(s)

Closes #44 

## Checklist

- [ ] added appropriate tests?
- [x] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
