### PR TITLE
chore(groupId): rename project groupId to org.eclipse.edc

### DIFF
--- a/client-cli/README.md
+++ b/client-cli/README.md
@@ -29,7 +29,7 @@ cd IdentityHub
 
 ```
 cd OtherDirectory
-mvn dependency:copy -Dartifact=org.eclipse.edc.identityhub:identity-hub-cli:0.0.1-SNAPSHOT:jar:all -DoutputDirectory=.
+mvn dependency:copy -Dartifact=org.eclipse.edc:identity-hub-cli:0.0.1-SNAPSHOT:jar:all -DoutputDirectory=.
 java -jar identity-hub-cli-0.0.1-SNAPSHOT-all.jar --help
 ```
 

--- a/core/identity-hub/bin/main/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
+++ b/core/identity-hub/bin/main/META-INF/services/org.eclipse.edc.spi.system.ServiceExtension
@@ -1,1 +1,0 @@
-org.eclipse.edc.identityhub.api.IdentityHubExtension

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-projectGroup=org.eclipse.edc.identityhub
+projectGroup=org.eclipse.edc
 # defaultVersion is used when "-PidentityHubVersion...." is no supplied. Should always be equal to edcVersion!
 defaultVersion=0.0.1-SNAPSHOT
 edcGroup=org.eclipse.edc


### PR DESCRIPTION
## What this PR changes/adds

Changes the project group from `org.eclipse.edc.identityhub` to `org.eclipse.edc`


## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
