### PR TITLE
fix(build): remove re-declaration of bouncycastle from version catalog

### DIFF
--- a/client-cli/build.gradle.kts
+++ b/client-cli/build.gradle.kts
@@ -14,7 +14,7 @@ dependencies {
     implementation(libs.jackson.databind)
     implementation(libs.okhttp)
     implementation(libs.nimbus.jwt)
-    implementation(libs.bouncycastle.bcpkix.jdk15on)
+    implementation(libs.bouncyCastle.bcpkix)
 }
 repositories {
     mavenCentral()

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,13 +3,9 @@ javaVersion=11
 # defaultVersion is used when "-PidentityHubVersion...." is no supplied. Should always be equal to edcVersion!
 defaultVersion=0.0.1-SNAPSHOT
 edcGroup=org.eclipse.edc
-edcVersion=0.0.1-20221113-SNAPSHOT
 edcGradlePluginsVersion=0.0.1-SNAPSHOT
 annotationProcessorVersion=0.0.1-SNAPSHOT
 metaModelVersion=0.0.1-SNAPSHOT
-swagger=2.1.13
-bouncyCastleVersion=1.70
-picocliVersion=4.6.3
 # information required for publishing artifacts:
 edcDeveloperId=mspiekermann
 edcDeveloperName=Markus Spiekermann

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,11 +1,5 @@
 rootProject.name = "identity-hub"
 
-val edcVersion: String by settings
-val bouncyCastleVersion: String by settings
-val picocliVersion: String by settings
-val edcGroup: String by settings
-val edcGradlePluginsVersion: String by settings
-
 // this is needed to have access to snapshot builds of plugins
 pluginManagement {
     repositories {
@@ -28,18 +22,15 @@ dependencyResolutionManagement {
     }
     versionCatalogs {
         create("libs") {
-            from("${edcGroup}:edc-versions:${edcGradlePluginsVersion}")
-            version("picocli", picocliVersion)
-            version("bouncycastle", bouncyCastleVersion)
+            from("org.eclipse.edc:edc-versions:0.0.1-SNAPSHOT")
+            version("picocli", "4.6.3")
 
             library("picocli-core", "info.picocli", "picocli").versionRef("picocli")
             library("picocli-codegen", "info.picocli", "picocli-codegen").versionRef("picocli")
-            library("bouncycastle-bcpkix-jdk15on", "org.bouncycastle", "bcpkix-jdk15on").versionRef("bouncycastle")
-
-
+            library("swagger-jaxrs", "io.swagger.core.v3", "swagger-jaxrs2-jakarta").version("2.1.13")
         }
         create("edc") {
-            version("edc", edcVersion)
+            version("edc", "0.0.1-20221113-SNAPSHOT")
             library("spi-core", "org.eclipse.edc", "core-spi").versionRef("edc")
             library("spi-transaction", "org.eclipse.edc", "transaction-spi").versionRef("edc")
             library("spi-transaction-datasource", "org.eclipse.edc", "transaction-datasource-spi").versionRef("edc")

--- a/spi/identity-hub-spi/build.gradle.kts
+++ b/spi/identity-hub-spi/build.gradle.kts
@@ -28,7 +28,7 @@ dependencies {
     implementation(edc.ext.identity.did.crypto)
 
 
-    implementation("io.swagger.core.v3:swagger-jaxrs2-jakarta:${swagger}") {
+    implementation(libs.swagger.jaxrs) {
         exclude(group = "com.fasterxml.jackson.jaxrs", module = "jackson-jaxrs-json-provider")
     }
 

--- a/system-tests/build.gradle.kts
+++ b/system-tests/build.gradle.kts
@@ -29,6 +29,6 @@ dependencies {
     testImplementation(libs.jackson.databind)
     testImplementation(libs.okhttp)
     testImplementation(libs.nimbus.jwt)
-    testImplementation(libs.bouncycastle.bcpkix.jdk15on)
+    testImplementation(libs.bouncyCastle.bcpkix)
 }
 


### PR DESCRIPTION
## What this PR changes/adds

Fixes a problem with the build:
```
* What went wrong:
A problem occurred configuring root project 'identity-hub'.
Could not create an instance of type org.gradle.accessors.dm.LibrariesForLibs.
Could not generate a decorated class for type LibrariesForLibs.
org/gradle/accessors/dm/LibrariesForLibs$BouncycastleLibraryAccessors (wrong name: org/gradle/accessors/dm/LibrariesForLibs$BouncyCastleLibraryAccessors)
```

This was caused by a re-declaration of the bouncyc-castle dependency, which I removed. The Version Catalog provided by EDC already has that dependency built-in.

## Why it does that

fix the build

## Further notes

- all version information is now centralized in `settings.gradle.kts`
- the dependency for the Swagger annotations was added to the `"libs"` version catalog

## Linked Issue(s)

.
## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [ ] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [ ] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
