### PR TITLE
build: add workflow to explicitly trigger Jenkins

### DIFF
--- a/.github/workflows/trigger_snapshot.yml
+++ b/.github/workflows/trigger_snapshot.yml
@@ -1,0 +1,31 @@
+name: "Create Snapshot Build"
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  Trigger-Snapshot:
+    runs-on: ubuntu-latest
+    steps:
+      # Trigger EF Jenkins. This job waits for Jenkins to complete the publishing, which may take a long time, because every
+      # module is signed individually, and parallelism is not available. Hence, the increased timeout of 3600 seconds.
+      # There is no way to cancel the process on Jenkins from withing GitHub.
+      - name: Call Jenkins API to trigger build
+        id: runjenkins
+        uses: toptal/jenkins-job-trigger-action@master
+        with:
+          jenkins_url: "https://ci.eclipse.org/dataspaceconnector/"
+          jenkins_user: ${{ secrets.EF_JENKINS_USER }}
+          jenkins_token: ${{ secrets.EF_JENKINS_TOKEN }}
+          # empty params are needed, otherwise the job will fail.
+          job_params: |
+            {
+            }
+          job_name: "IdentityHub-Snapshot"
+          job_timeout: "3600" # Default 30 sec. (optional)
+
+      - name: Log Jenkins URL
+        run:
+          echo "::notice title=Jenkins URL::${{ steps.runjenkins.outputs.jenkins_job_url }} "


### PR DESCRIPTION
## What this PR changes/adds

Explicitly triggers Jenkins on every build on the `main` branch.

## Why it does that

more reactive build

## Further notes
.

## Linked Issue(s)

Partly resolves https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/issues/2234

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [x] assigned appropriate label? (exclude from changelog with label `no-changelog`)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [Etiquette for pull requests](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/pr_etiquette.md) for details_)
