### PR TITLE
chore: use SNAPSHOT version of EDC

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -56,17 +56,17 @@ jobs:
       - name: 'Unit and system tests'
         uses: ./.github/actions/run-tests
         with:
-            command: ./gradlew test
+          command: ./gradlew test
         timeout-minutes: 10
         env:
           INTEGRATION_TEST: true
           JACOCO: "true"
 
-      - name: 'Publish Test Results'
-        uses: EnricoMi/publish-unit-test-result-action@v1
-        if: always()
-        with:
-          files: "**/test-results/**/*.xml"
+      #      - name: 'Publish Test Results'
+      #        uses: EnricoMi/publish-unit-test-result-action@v1
+      #        if: always()
+      #        with:
+      #          files: "**/test-results/**/*.xml"
 
       - name: 'docker-compose logs'
         run: docker-compose -f system-tests/docker-compose.yml logs

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -30,7 +30,7 @@ dependencyResolutionManagement {
             library("swagger-jaxrs", "io.swagger.core.v3", "swagger-jaxrs2-jakarta").version("2.1.13")
         }
         create("edc") {
-            version("edc", "0.0.1-20221113-SNAPSHOT")
+            version("edc", "0.0.1-SNAPSHOT")
             library("spi-core", "org.eclipse.edc", "core-spi").versionRef("edc")
             library("spi-transaction", "org.eclipse.edc", "transaction-spi").versionRef("edc")
             library("spi-transaction-datasource", "org.eclipse.edc", "transaction-datasource-spi").versionRef("edc")


### PR DESCRIPTION
## What this PR changes/adds

Use the SNAPSHOT version of EDC

## Why it does that

to have the ability for cascaded builds and up-to-date versions, avoid feature gaps

## Further notes

- disabled a failing action for now, will re-enable before merging

## Linked Issue(s)

.

## Checklist

- [ ] added appropriate tests?
- [ ] performed checkstyle check locally?
- [ ] added/updated copyright headers?
- [ ] documented public classes/methods?
- [ ] added/updated relevant documentation?
- [x] added relevant details to the changelog? (_skip with label `no-changelog`_)
- [x] formatted title correctly? (_take a look at the [CONTRIBUTING](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/CONTRIBUTING.md#submit-a-pull-request) and [styleguide](https://github.com/eclipse-dataspaceconnector/DataSpaceConnector/blob/main/styleguide.md) for details_)
